### PR TITLE
Add multi-tenant Alliance Dashboard client

### DIFF
--- a/Clients/alliance/.env.example
+++ b/Clients/alliance/.env.example
@@ -1,0 +1,48 @@
+# Conlyse Alliance Dashboard - Environment Configuration
+# Copy this file to .env and update the values
+
+# =============================================================================
+# Database Configuration
+# =============================================================================
+
+# If using docker-compose.yml (includes new database)
+MYSQL_ROOT_PASSWORD=your-root-password
+MYSQL_DATABASE=conlyse
+MYSQL_USER=conlyse
+MYSQL_USER_PASSWORD=your-db-password
+
+# If using docker-compose.external-db.yml (connecting to existing database)
+# MYSQL_IP_ADDR=your-database-host
+# MYSQL_DATABASE=your-database-name
+# MYSQL_USER=your-database-user
+# MYSQL_USER_PASSWORD=your-database-password
+
+# =============================================================================
+# Security Configuration
+# =============================================================================
+
+# Flask secret key (generate with: python -c "import secrets; print(secrets.token_hex(32))")
+FLASK_SECRET=your-flask-secret-key-change-this
+
+# JWT secret key (generate with: python -c "import secrets; print(secrets.token_hex(32))")
+JWT_SECRET=your-jwt-secret-key-change-this
+
+# JWT token expiration in hours
+JWT_EXPIRATION_HOURS=24
+
+# =============================================================================
+# Application Configuration
+# =============================================================================
+
+# Enable debug mode (set to 'false' in production)
+DEBUG=false
+
+# Allowed CORS origins (comma-separated, or * for all)
+CORS_ORIGINS=*
+
+# =============================================================================
+# Cloudflare Configuration (Optional)
+# =============================================================================
+
+# If deploying behind Cloudflare, add your domain here
+# CORS_ORIGINS=https://your-domain.com,https://www.your-domain.com

--- a/Clients/alliance/README.md
+++ b/Clients/alliance/README.md
@@ -1,0 +1,212 @@
+# Conlyse Alliance Dashboard
+
+A multi-tenant dashboard for Conflict of Nations players to track their games and collaborate with alliance members.
+
+## Features
+
+- **User Authentication**: Verify identity using Conflict of Nations credentials
+- **Personal Dashboard**: View your games, stats, and progress across all tracked games
+- **Alliance Management**: Create and join alliances with other players
+- **Alliance Dashboard**: See all games where alliance members are playing
+- **Secure**: Passwords are hashed, JWT-based authentication, CoN credentials are verified but not stored
+
+## Quick Start
+
+### Option 1: Fresh Installation (New Database)
+
+1. Clone or copy the alliance folder
+2. Create environment file:
+   ```bash
+   cp .env.example .env
+   # Edit .env with your settings
+   ```
+3. Start with Docker Compose:
+   ```bash
+   docker-compose up -d
+   ```
+4. Access at `http://localhost`
+
+### Option 2: Connect to Existing Conlyse Database
+
+1. Create environment file:
+   ```bash
+   cp .env.example .env
+   ```
+2. Edit `.env` with your existing database credentials:
+   ```
+   MYSQL_IP_ADDR=your-database-host
+   MYSQL_DATABASE=your-database-name
+   MYSQL_USER=your-database-user
+   MYSQL_USER_PASSWORD=your-database-password
+   ```
+3. Start with external database compose file:
+   ```bash
+   docker-compose -f docker-compose.external-db.yml up -d
+   ```
+
+## Cloudflare Deployment
+
+### Using Cloudflare Containers
+
+1. Build and push your images to a container registry:
+   ```bash
+   docker build -t your-registry/conlyse-alliance-backend ./backend
+   docker build -t your-registry/conlyse-alliance-frontend ./frontend
+   docker push your-registry/conlyse-alliance-backend
+   docker push your-registry/conlyse-alliance-frontend
+   ```
+
+2. Deploy to Cloudflare Containers following their documentation
+
+3. Configure environment variables in Cloudflare dashboard
+
+### Using Cloudflare Tunnel (Recommended for Self-Hosted)
+
+1. Install cloudflared:
+   ```bash
+   # On Ubuntu/Debian
+   curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o cloudflared.deb
+   sudo dpkg -i cloudflared.deb
+   ```
+
+2. Authenticate and create tunnel:
+   ```bash
+   cloudflared tunnel login
+   cloudflared tunnel create conlyse-alliance
+   ```
+
+3. Create tunnel config (`~/.cloudflared/config.yml`):
+   ```yaml
+   tunnel: YOUR_TUNNEL_ID
+   credentials-file: /root/.cloudflared/YOUR_TUNNEL_ID.json
+
+   ingress:
+     - hostname: alliance.yourdomain.com
+       service: http://localhost:80
+     - service: http_status:404
+   ```
+
+4. Run the tunnel:
+   ```bash
+   cloudflared tunnel run conlyse-alliance
+   ```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Frontend (React)                      │
+│                   - Login/Register pages                     │
+│                   - Personal Dashboard                       │
+│                   - Alliance Management                      │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              │ HTTP/HTTPS
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                      Backend API (Flask)                     │
+│                   - JWT Authentication                       │
+│                   - Alliance CRUD                            │
+│                   - Dashboard Data                           │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              │ SQLAlchemy
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    MySQL Database                            │
+│              - Existing Conlyse tables                       │
+│              - New alliance_* tables                         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## API Endpoints
+
+### Authentication
+- `POST /api/auth/register` - Register new user (requires CoN credentials)
+- `POST /api/auth/login` - Login with dashboard password
+- `GET /api/auth/me` - Get current user info
+- `POST /api/auth/refresh` - Refresh JWT token
+
+### Alliances
+- `GET /api/alliances` - List user's alliances
+- `POST /api/alliances` - Create new alliance
+- `GET /api/alliances/:id` - Get alliance details
+- `POST /api/alliances/join` - Join alliance with invite code
+- `POST /api/alliances/:id/leave` - Leave alliance
+- `POST /api/alliances/:id/regenerate-invite` - Regenerate invite code
+
+### Dashboard
+- `GET /api/dashboard/my-games` - Get user's games
+- `GET /api/dashboard/my-stats/:gameId` - Get user's stats for a game
+- `GET /api/dashboard/alliance/:allianceId/games` - Get alliance games
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FLASK_SECRET` | Flask session secret key | Random |
+| `JWT_SECRET` | JWT signing secret | Random |
+| `JWT_EXPIRATION_HOURS` | Token expiration time | 24 |
+| `MYSQL_USER` | Database username | conlyse |
+| `MYSQL_USER_PASSWORD` | Database password | - |
+| `MYSQL_IP_ADDR` | Database host | db |
+| `MYSQL_DATABASE` | Database name | conlyse |
+| `DEBUG` | Enable debug mode | false |
+| `CORS_ORIGINS` | Allowed CORS origins | * |
+
+## Development
+
+### Backend
+```bash
+cd backend
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python api.py
+```
+
+### Frontend
+```bash
+cd frontend
+npm install
+npm start
+```
+
+## Security Notes
+
+1. **CoN Password Verification**: The CoN password is only used during registration to verify the user owns the account. It is NOT stored.
+
+2. **Dashboard Password**: Users create a separate password for the dashboard, which is hashed using Werkzeug's secure password hashing.
+
+3. **JWT Tokens**: Authentication uses JWT tokens with configurable expiration.
+
+4. **HTTPS**: Always use HTTPS in production. Cloudflare provides this automatically.
+
+## Database Tables
+
+The alliance dashboard creates these additional tables:
+
+- `alliance_user` - Dashboard user accounts
+- `alliance` - Alliance definitions
+- `alliance_membership` - User-Alliance relationships
+- `alliance_watched_game` - Games tracked by alliances
+
+These tables are created automatically on first run and don't interfere with existing Conlyse tables.
+
+## Troubleshooting
+
+### "Could not verify CoN credentials"
+- Check that the CoN username and password are correct
+- The CoN servers may be temporarily unavailable
+
+### "No tracked games found"
+- Ensure the Conlyse bot is running and tracking games
+- The username must match exactly (case-insensitive)
+
+### Database connection errors
+- Verify database credentials in `.env`
+- Ensure the database is accessible from the container
+
+## License
+
+MIT License - See LICENSE file for details.

--- a/Clients/alliance/backend/.gitignore
+++ b/Clients/alliance/backend/.gitignore
@@ -1,0 +1,25 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+venv/
+env/
+.venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Environment files
+.env
+
+# Logs
+*.log
+
+# Local development
+*.db
+*.sqlite3

--- a/Clients/alliance/backend/Dockerfile
+++ b/Clients/alliance/backend/Dockerfile
@@ -1,0 +1,28 @@
+# Backend Dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    default-libmysqlclient-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Create non-root user
+RUN useradd -m appuser && chown -R appuser:appuser /app
+USER appuser
+
+# Expose port
+EXPOSE 5000
+
+# Run with gunicorn
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "120", "api:app"]

--- a/Clients/alliance/backend/api.py
+++ b/Clients/alliance/backend/api.py
@@ -1,0 +1,784 @@
+"""
+Alliance Dashboard API
+Flask REST API for user authentication, alliance management, and personalized dashboards.
+"""
+import os
+import secrets
+from datetime import datetime, timedelta
+from functools import wraps
+
+from flask import Flask, jsonify, request, g
+from flask_cors import CORS
+from flask_compress import Compress
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import func, and_, or_, case
+from sqlalchemy.orm import aliased
+import jwt
+
+from dotenv import load_dotenv
+
+from models import Base, User, Alliance, AllianceMembership, WatchedGame
+from con_auth import verify_con_credentials
+
+# Load environment variables
+load_dotenv()
+
+# Initialize Flask app
+app = Flask(__name__)
+
+# Configuration
+app.config['SECRET_KEY'] = os.getenv('FLASK_SECRET', secrets.token_hex(32))
+app.config['JWT_SECRET'] = os.getenv('JWT_SECRET', secrets.token_hex(32))
+app.config['JWT_EXPIRATION_HOURS'] = int(os.getenv('JWT_EXPIRATION_HOURS', 24))
+
+# Database configuration - connects to existing Conlyse database
+app.config['SQLALCHEMY_DATABASE_URI'] = (
+    f"mysql+mysqlconnector://{os.getenv('MYSQL_USER')}:{os.getenv('MYSQL_USER_PASSWORD')}"
+    f"@{os.getenv('MYSQL_IP_ADDR')}/{os.getenv('MYSQL_DATABASE')}"
+)
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SQLALCHEMY_ECHO'] = os.getenv('DEBUG', 'false').lower() == 'true'
+
+# Initialize extensions
+db = SQLAlchemy(app)
+Compress(app)
+CORS(app, origins=os.getenv('CORS_ORIGINS', '*').split(','))
+
+
+# Import existing Conlyse models for data access
+from sqlalchemy import BigInteger, Boolean, Column, Float, ForeignKey, Integer, String, TIMESTAMP
+from sqlalchemy.orm import relationship
+
+
+class Player(db.Model):
+    """Existing player table from Conlyse."""
+    __tablename__ = 'player'
+    __table_args__ = {'extend_existing': True}
+
+    player_id = Column(BigInteger, primary_key=True, nullable=False, autoincrement=True)
+    site_user_id = Column(Integer, primary_key=True, nullable=False)
+    name = Column(String(75), nullable=False)
+
+
+class Game(db.Model):
+    """Existing game table from Conlyse."""
+    __tablename__ = 'game'
+    __table_args__ = {'extend_existing': True}
+
+    game_id = Column(Integer, primary_key=True)
+    scenario_id = Column(Integer, nullable=False)
+    start_time = Column(TIMESTAMP)
+    end_time = Column(TIMESTAMP)
+    current_time = Column(TIMESTAMP)
+    next_day_time = Column(TIMESTAMP)
+    open_slots = Column(Integer)
+
+
+class Scenario(db.Model):
+    """Existing scenario table from Conlyse."""
+    __tablename__ = 'scenario'
+    __table_args__ = {'extend_existing': True}
+
+    scenario_id = Column(Integer, primary_key=True)
+    map_id = Column(Integer)
+    name = Column(String(45))
+    speed = Column(Integer)
+
+
+class GameHasPlayer(db.Model):
+    """Existing game_has_player table from Conlyse."""
+    __tablename__ = 'game_has_player'
+    __table_args__ = {'extend_existing': True}
+
+    game_id = Column(Integer, ForeignKey('game.game_id'), primary_key=True, nullable=False)
+    player_id = Column(BigInteger, ForeignKey('player.player_id'), primary_key=True, nullable=False)
+    country_id = Column(BigInteger, nullable=False)
+
+
+class Country(db.Model):
+    """Existing country table from Conlyse."""
+    __tablename__ = 'country'
+    __table_args__ = {'extend_existing': True}
+
+    universal_country_id = Column(BigInteger, primary_key=True, nullable=False, autoincrement=True)
+    country_id = Column(BigInteger, nullable=False)
+    team_id = Column(Integer)
+    capital_id = Column(Integer)
+    defeated = Column(Boolean)
+    computer = Column(Boolean)
+    valid_from = Column(TIMESTAMP, nullable=False)
+    valid_until = Column(TIMESTAMP)
+    game_id = Column(Integer, ForeignKey('game.game_id'), primary_key=True, nullable=False)
+    static_country_id = Column(Integer, primary_key=True, nullable=False)
+
+
+class StaticCountry(db.Model):
+    """Existing static_country table from Conlyse."""
+    __tablename__ = 'static_country'
+    __table_args__ = {'extend_existing': True}
+
+    static_country_id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(45))
+    map_id = Column(Integer)
+    native_computer = Column(Boolean)
+    country_id = Column(Integer)
+    faction = Column(Integer)
+
+
+class Province(db.Model):
+    """Existing province table from Conlyse."""
+    __tablename__ = 'province'
+    __table_args__ = {'extend_existing': True}
+
+    province_id = Column(BigInteger, primary_key=True, nullable=False, autoincrement=True)
+    owner_id = Column(BigInteger, nullable=False)
+    morale = Column(Integer)
+    province_state_id = Column(Integer)
+    victory_points = Column(Integer)
+    resource_production = Column(Integer)
+    tax_production = Column(Integer)
+    valid_from = Column(TIMESTAMP, nullable=False)
+    valid_until = Column(TIMESTAMP)
+    game_id = Column(Integer, ForeignKey('game.game_id'), primary_key=True, nullable=False)
+    static_province_id = Column(Integer, primary_key=True, nullable=False)
+
+
+# Create alliance tables
+with app.app_context():
+    Base.metadata.create_all(db.engine)
+
+
+# =============================================================================
+# JWT Authentication
+# =============================================================================
+
+def generate_token(user_id: int) -> str:
+    """Generate a JWT token for a user."""
+    payload = {
+        'user_id': user_id,
+        'exp': datetime.utcnow() + timedelta(hours=app.config['JWT_EXPIRATION_HOURS']),
+        'iat': datetime.utcnow(),
+    }
+    return jwt.encode(payload, app.config['JWT_SECRET'], algorithm='HS256')
+
+
+def verify_token(token: str) -> dict:
+    """Verify and decode a JWT token."""
+    try:
+        payload = jwt.decode(token, app.config['JWT_SECRET'], algorithms=['HS256'])
+        return payload
+    except jwt.ExpiredSignatureError:
+        return None
+    except jwt.InvalidTokenError:
+        return None
+
+
+def token_required(f):
+    """Decorator to require valid JWT token for protected routes."""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = None
+
+        # Get token from header
+        if 'Authorization' in request.headers:
+            auth_header = request.headers['Authorization']
+            if auth_header.startswith('Bearer '):
+                token = auth_header.split(' ')[1]
+
+        if not token:
+            return jsonify({'error': 'Token is missing'}), 401
+
+        payload = verify_token(token)
+        if not payload:
+            return jsonify({'error': 'Token is invalid or expired'}), 401
+
+        # Get user from database
+        user = db.session.get(User, payload['user_id'])
+        if not user or not user.is_active:
+            return jsonify({'error': 'User not found or inactive'}), 401
+
+        g.current_user = user
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+# =============================================================================
+# Authentication Endpoints
+# =============================================================================
+
+@app.route('/api/auth/register', methods=['POST'])
+def register():
+    """
+    Register a new user with CoN credentials.
+    Verifies credentials against CoN servers before creating account.
+    """
+    data = request.get_json()
+
+    if not data:
+        return jsonify({'error': 'No data provided'}), 400
+
+    con_username = data.get('con_username', '').strip()
+    con_password = data.get('con_password', '')
+    dashboard_password = data.get('dashboard_password', '')
+    email = data.get('email', '').strip() or None
+
+    if not con_username or not con_password or not dashboard_password:
+        return jsonify({'error': 'CoN username, CoN password, and dashboard password are required'}), 400
+
+    if len(dashboard_password) < 8:
+        return jsonify({'error': 'Dashboard password must be at least 8 characters'}), 400
+
+    # Check if user already exists
+    existing_user = db.session.query(User).filter(
+        func.lower(User.con_username) == con_username.lower()
+    ).first()
+
+    if existing_user:
+        return jsonify({'error': 'User with this CoN username already registered'}), 409
+
+    # Verify CoN credentials
+    auth_result = verify_con_credentials(con_username, con_password)
+
+    if not auth_result['success']:
+        return jsonify({
+            'error': 'Could not verify CoN credentials',
+            'details': auth_result.get('error', 'Unknown error')
+        }), 401
+
+    # Try to find player in existing Conlyse data
+    player = db.session.query(Player).filter(
+        func.lower(Player.name) == con_username.lower()
+    ).first()
+
+    # Create new user
+    user = User(
+        con_username=con_username,
+        con_player_id=auth_result.get('player_id') or (player.player_id if player else None),
+        con_site_user_id=auth_result.get('site_user_id') or (player.site_user_id if player else None),
+        email=email,
+    )
+    user.set_password(dashboard_password)
+
+    db.session.add(user)
+    db.session.commit()
+
+    # Generate token
+    token = generate_token(user.user_id)
+
+    return jsonify({
+        'message': 'Registration successful',
+        'token': token,
+        'user': user.to_dict(),
+    }), 201
+
+
+@app.route('/api/auth/login', methods=['POST'])
+def login():
+    """
+    Log in with dashboard credentials.
+    """
+    data = request.get_json()
+
+    if not data:
+        return jsonify({'error': 'No data provided'}), 400
+
+    con_username = data.get('con_username', '').strip()
+    password = data.get('password', '')
+
+    if not con_username or not password:
+        return jsonify({'error': 'Username and password are required'}), 400
+
+    # Find user
+    user = db.session.query(User).filter(
+        func.lower(User.con_username) == con_username.lower()
+    ).first()
+
+    if not user or not user.check_password(password):
+        return jsonify({'error': 'Invalid username or password'}), 401
+
+    if not user.is_active:
+        return jsonify({'error': 'Account is deactivated'}), 401
+
+    # Update last login
+    user.last_login = datetime.utcnow()
+    db.session.commit()
+
+    # Generate token
+    token = generate_token(user.user_id)
+
+    return jsonify({
+        'message': 'Login successful',
+        'token': token,
+        'user': user.to_dict(),
+    })
+
+
+@app.route('/api/auth/me', methods=['GET'])
+@token_required
+def get_current_user():
+    """Get current authenticated user's info."""
+    user = g.current_user
+
+    # Get user's alliances
+    memberships = db.session.query(AllianceMembership).filter(
+        AllianceMembership.user_id == user.user_id
+    ).all()
+
+    alliances = []
+    for m in memberships:
+        alliance_data = m.alliance.to_dict()
+        alliance_data['role'] = m.role
+        alliances.append(alliance_data)
+
+    return jsonify({
+        'user': user.to_dict(),
+        'alliances': alliances,
+    })
+
+
+@app.route('/api/auth/refresh', methods=['POST'])
+@token_required
+def refresh_token():
+    """Refresh the JWT token."""
+    user = g.current_user
+    token = generate_token(user.user_id)
+    return jsonify({'token': token})
+
+
+# =============================================================================
+# Alliance Endpoints
+# =============================================================================
+
+@app.route('/api/alliances', methods=['GET'])
+@token_required
+def list_alliances():
+    """List alliances the current user belongs to."""
+    user = g.current_user
+
+    memberships = db.session.query(AllianceMembership).filter(
+        AllianceMembership.user_id == user.user_id
+    ).all()
+
+    alliances = []
+    for m in memberships:
+        alliance_data = m.alliance.to_dict(include_members=True)
+        alliance_data['my_role'] = m.role
+        alliances.append(alliance_data)
+
+    return jsonify({'alliances': alliances})
+
+
+@app.route('/api/alliances', methods=['POST'])
+@token_required
+def create_alliance():
+    """Create a new alliance."""
+    user = g.current_user
+    data = request.get_json()
+
+    if not data:
+        return jsonify({'error': 'No data provided'}), 400
+
+    name = data.get('name', '').strip()
+    tag = data.get('tag', '').strip().upper()
+    description = data.get('description', '').strip() or None
+    is_public = data.get('is_public', False)
+
+    if not name or not tag:
+        return jsonify({'error': 'Alliance name and tag are required'}), 400
+
+    if len(tag) > 10:
+        return jsonify({'error': 'Tag must be 10 characters or less'}), 400
+
+    # Check for existing alliance with same name or tag
+    existing = db.session.query(Alliance).filter(
+        or_(
+            func.lower(Alliance.name) == name.lower(),
+            func.lower(Alliance.tag) == tag.lower()
+        )
+    ).first()
+
+    if existing:
+        return jsonify({'error': 'Alliance with this name or tag already exists'}), 409
+
+    # Create alliance
+    alliance = Alliance(
+        name=name,
+        tag=tag,
+        description=description,
+        owner_id=user.user_id,
+        invite_code=secrets.token_urlsafe(16),
+        is_public=is_public,
+    )
+    db.session.add(alliance)
+    db.session.flush()  # Get alliance_id
+
+    # Add owner as member with owner role
+    membership = AllianceMembership(
+        user_id=user.user_id,
+        alliance_id=alliance.alliance_id,
+        role='owner',
+    )
+    db.session.add(membership)
+    db.session.commit()
+
+    return jsonify({
+        'message': 'Alliance created successfully',
+        'alliance': alliance.to_dict(include_members=True),
+    }), 201
+
+
+@app.route('/api/alliances/<int:alliance_id>', methods=['GET'])
+@token_required
+def get_alliance(alliance_id):
+    """Get alliance details (must be a member)."""
+    user = g.current_user
+
+    # Check membership
+    membership = db.session.query(AllianceMembership).filter(
+        AllianceMembership.alliance_id == alliance_id,
+        AllianceMembership.user_id == user.user_id
+    ).first()
+
+    if not membership:
+        return jsonify({'error': 'You are not a member of this alliance'}), 403
+
+    alliance = db.session.get(Alliance, alliance_id)
+    if not alliance:
+        return jsonify({'error': 'Alliance not found'}), 404
+
+    return jsonify({
+        'alliance': alliance.to_dict(include_members=True),
+        'my_role': membership.role,
+    })
+
+
+@app.route('/api/alliances/join', methods=['POST'])
+@token_required
+def join_alliance():
+    """Join an alliance using invite code."""
+    user = g.current_user
+    data = request.get_json()
+
+    invite_code = data.get('invite_code', '').strip()
+    if not invite_code:
+        return jsonify({'error': 'Invite code is required'}), 400
+
+    alliance = db.session.query(Alliance).filter(
+        Alliance.invite_code == invite_code
+    ).first()
+
+    if not alliance:
+        return jsonify({'error': 'Invalid invite code'}), 404
+
+    # Check if already a member
+    existing = db.session.query(AllianceMembership).filter(
+        AllianceMembership.alliance_id == alliance.alliance_id,
+        AllianceMembership.user_id == user.user_id
+    ).first()
+
+    if existing:
+        return jsonify({'error': 'You are already a member of this alliance'}), 409
+
+    # Join alliance
+    membership = AllianceMembership(
+        user_id=user.user_id,
+        alliance_id=alliance.alliance_id,
+        role='member',
+    )
+    db.session.add(membership)
+    db.session.commit()
+
+    return jsonify({
+        'message': 'Successfully joined alliance',
+        'alliance': alliance.to_dict(),
+    })
+
+
+@app.route('/api/alliances/<int:alliance_id>/leave', methods=['POST'])
+@token_required
+def leave_alliance(alliance_id):
+    """Leave an alliance."""
+    user = g.current_user
+
+    membership = db.session.query(AllianceMembership).filter(
+        AllianceMembership.alliance_id == alliance_id,
+        AllianceMembership.user_id == user.user_id
+    ).first()
+
+    if not membership:
+        return jsonify({'error': 'You are not a member of this alliance'}), 404
+
+    if membership.role == 'owner':
+        return jsonify({'error': 'Owner cannot leave. Transfer ownership first or delete the alliance.'}), 400
+
+    db.session.delete(membership)
+    db.session.commit()
+
+    return jsonify({'message': 'Successfully left alliance'})
+
+
+@app.route('/api/alliances/<int:alliance_id>/regenerate-invite', methods=['POST'])
+@token_required
+def regenerate_invite_code(alliance_id):
+    """Regenerate alliance invite code (admin/owner only)."""
+    user = g.current_user
+
+    membership = db.session.query(AllianceMembership).filter(
+        AllianceMembership.alliance_id == alliance_id,
+        AllianceMembership.user_id == user.user_id
+    ).first()
+
+    if not membership or membership.role not in ['owner', 'admin']:
+        return jsonify({'error': 'Admin privileges required'}), 403
+
+    alliance = db.session.get(Alliance, alliance_id)
+    alliance.invite_code = secrets.token_urlsafe(16)
+    db.session.commit()
+
+    return jsonify({
+        'message': 'Invite code regenerated',
+        'invite_code': alliance.invite_code,
+    })
+
+
+# =============================================================================
+# Dashboard Endpoints
+# =============================================================================
+
+@app.route('/api/dashboard/my-games', methods=['GET'])
+@token_required
+def get_my_games():
+    """Get games where the current user is playing."""
+    user = g.current_user
+
+    if not user.con_player_id:
+        # Try to find player by username
+        player = db.session.query(Player).filter(
+            func.lower(Player.name) == user.con_username.lower()
+        ).first()
+
+        if not player:
+            return jsonify({'games': [], 'message': 'No tracked games found for your account'})
+
+        player_id = player.player_id
+    else:
+        player_id = user.con_player_id
+
+    # Get all games for this player
+    games_query = db.session.query(
+        Game.game_id,
+        Game.current_time,
+        Game.start_time,
+        Game.end_time,
+        Scenario.name.label('scenario_name'),
+        Scenario.speed,
+        Scenario.map_id,
+        GameHasPlayer.country_id,
+        StaticCountry.name.label('country_name'),
+    ).join(
+        GameHasPlayer, Game.game_id == GameHasPlayer.game_id
+    ).join(
+        Scenario, Game.scenario_id == Scenario.scenario_id
+    ).outerjoin(
+        Country, and_(
+            Country.game_id == Game.game_id,
+            Country.country_id == GameHasPlayer.country_id,
+            Country.valid_until == None
+        )
+    ).outerjoin(
+        StaticCountry, Country.static_country_id == StaticCountry.static_country_id
+    ).filter(
+        GameHasPlayer.player_id == player_id
+    ).order_by(Game.start_time.desc())
+
+    games = []
+    for g_data in games_query.all():
+        games.append({
+            'game_id': g_data.game_id,
+            'scenario_name': g_data.scenario_name,
+            'speed': g_data.speed,
+            'map_id': g_data.map_id,
+            'country_id': g_data.country_id,
+            'country_name': g_data.country_name,
+            'start_time': g_data.start_time.timestamp() if g_data.start_time else None,
+            'current_time': g_data.current_time.timestamp() if g_data.current_time else None,
+            'end_time': g_data.end_time.timestamp() if g_data.end_time else None,
+            'is_active': g_data.end_time is None,
+        })
+
+    return jsonify({'games': games})
+
+
+@app.route('/api/dashboard/my-stats/<int:game_id>', methods=['GET'])
+@token_required
+def get_my_game_stats(game_id):
+    """Get the current user's stats for a specific game."""
+    user = g.current_user
+
+    # Find player
+    if not user.con_player_id:
+        player = db.session.query(Player).filter(
+            func.lower(Player.name) == user.con_username.lower()
+        ).first()
+        if not player:
+            return jsonify({'error': 'Player not found'}), 404
+        player_id = player.player_id
+    else:
+        player_id = user.con_player_id
+
+    # Get country_id for this game
+    game_player = db.session.query(GameHasPlayer).filter(
+        GameHasPlayer.game_id == game_id,
+        GameHasPlayer.player_id == player_id
+    ).first()
+
+    if not game_player:
+        return jsonify({'error': 'You are not in this game'}), 404
+
+    country_id = game_player.country_id
+
+    # Get current country stats
+    country_stats = db.session.query(
+        func.sum(Province.victory_points).label('victory_points'),
+        func.avg(Province.morale).label('avg_morale'),
+        func.count(Province.province_id).label('province_count'),
+        func.sum(Province.resource_production).label('total_resources'),
+        func.sum(Province.tax_production).label('total_tax'),
+    ).filter(
+        Province.game_id == game_id,
+        Province.owner_id == country_id,
+        Province.valid_until == None
+    ).first()
+
+    # Get country info
+    country = db.session.query(
+        Country, StaticCountry
+    ).join(
+        StaticCountry, Country.static_country_id == StaticCountry.static_country_id
+    ).filter(
+        Country.game_id == game_id,
+        Country.country_id == country_id,
+        Country.valid_until == None
+    ).first()
+
+    return jsonify({
+        'game_id': game_id,
+        'country_id': country_id,
+        'country_name': country.StaticCountry.name if country else None,
+        'defeated': country.Country.defeated if country else False,
+        'stats': {
+            'victory_points': int(country_stats.victory_points or 0),
+            'avg_morale': round(country_stats.avg_morale or 0, 1),
+            'province_count': int(country_stats.province_count or 0),
+            'total_resources': int(country_stats.total_resources or 0),
+            'total_tax': int(country_stats.total_tax or 0),
+        }
+    })
+
+
+@app.route('/api/dashboard/alliance/<int:alliance_id>/games', methods=['GET'])
+@token_required
+def get_alliance_games(alliance_id):
+    """Get all games where alliance members are playing."""
+    user = g.current_user
+
+    # Check membership
+    membership = db.session.query(AllianceMembership).filter(
+        AllianceMembership.alliance_id == alliance_id,
+        AllianceMembership.user_id == user.user_id
+    ).first()
+
+    if not membership:
+        return jsonify({'error': 'You are not a member of this alliance'}), 403
+
+    # Get all alliance members' player IDs
+    members = db.session.query(AllianceMembership, User).join(
+        User, AllianceMembership.user_id == User.user_id
+    ).filter(
+        AllianceMembership.alliance_id == alliance_id
+    ).all()
+
+    player_ids = []
+    username_to_user = {}
+    for m, u in members:
+        if u.con_player_id:
+            player_ids.append(u.con_player_id)
+        username_to_user[u.con_username.lower()] = u
+
+    # Also find players by username
+    players = db.session.query(Player).filter(
+        func.lower(Player.name).in_([un.lower() for un in username_to_user.keys()])
+    ).all()
+
+    for p in players:
+        if p.player_id not in player_ids:
+            player_ids.append(p.player_id)
+
+    if not player_ids:
+        return jsonify({'games': []})
+
+    # Get all games for these players
+    games_query = db.session.query(
+        Game.game_id,
+        Game.current_time,
+        Game.start_time,
+        Game.end_time,
+        Scenario.name.label('scenario_name'),
+        Scenario.speed,
+    ).join(
+        GameHasPlayer, Game.game_id == GameHasPlayer.game_id
+    ).join(
+        Scenario, Game.scenario_id == Scenario.scenario_id
+    ).filter(
+        GameHasPlayer.player_id.in_(player_ids)
+    ).distinct().order_by(Game.start_time.desc())
+
+    games = []
+    for g_data in games_query.all():
+        # Get members playing in this game
+        members_in_game = db.session.query(
+            GameHasPlayer.country_id,
+            Player.name
+        ).join(
+            Player, GameHasPlayer.player_id == Player.player_id
+        ).filter(
+            GameHasPlayer.game_id == g_data.game_id,
+            GameHasPlayer.player_id.in_(player_ids)
+        ).all()
+
+        games.append({
+            'game_id': g_data.game_id,
+            'scenario_name': g_data.scenario_name,
+            'speed': g_data.speed,
+            'start_time': g_data.start_time.timestamp() if g_data.start_time else None,
+            'current_time': g_data.current_time.timestamp() if g_data.current_time else None,
+            'end_time': g_data.end_time.timestamp() if g_data.end_time else None,
+            'is_active': g_data.end_time is None,
+            'members': [{'player_name': m.name, 'country_id': m.country_id} for m in members_in_game],
+        })
+
+    return jsonify({'games': games})
+
+
+# =============================================================================
+# Health Check
+# =============================================================================
+
+@app.route('/api/health', methods=['GET'])
+def health_check():
+    """Health check endpoint."""
+    return jsonify({
+        'status': 'healthy',
+        'timestamp': datetime.utcnow().isoformat(),
+    })
+
+
+# =============================================================================
+# Run Server
+# =============================================================================
+
+if __name__ == '__main__':
+    port = int(os.getenv('API_PORT', 5000))
+    debug = os.getenv('DEBUG', 'false').lower() == 'true'
+    app.run(host='0.0.0.0', port=port, debug=debug)

--- a/Clients/alliance/backend/con_auth.py
+++ b/Clients/alliance/backend/con_auth.py
@@ -1,0 +1,154 @@
+"""
+Conflict of Nations authentication service.
+Verifies user credentials against the CoN game servers.
+"""
+import requests
+import logging
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+
+logger = logging.getLogger(__name__)
+
+CON_BASE_URL = "https://www.conflictnations.com/"
+CON_LOGIN_URL = "https://www.conflictnations.com/index.php?id=2&L=0"
+
+
+class ConAuthService:
+    """
+    Service to authenticate users against Conflict of Nations.
+    """
+
+    def __init__(self):
+        self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.5',
+        })
+
+    def verify_credentials(self, username: str, password: str) -> dict:
+        """
+        Verify CoN credentials by attempting to log in.
+
+        Returns:
+            dict with keys:
+                - success: bool
+                - player_id: int (if successful)
+                - site_user_id: int (if successful)
+                - error: str (if failed)
+        """
+        try:
+            # First, get the login page to obtain any CSRF tokens
+            login_page = self.session.get(CON_BASE_URL, timeout=30)
+            login_page.raise_for_status()
+
+            # Attempt login via the game's AJAX login endpoint
+            login_data = {
+                'login': username,
+                'password': password,
+                'remember': '1',
+            }
+
+            # CoN uses an AJAX login endpoint
+            login_response = self.session.post(
+                'https://www.conflictnations.com/index.php?eID=api&key=userHandler&action=doLogin',
+                data=login_data,
+                timeout=30
+            )
+
+            if login_response.status_code != 200:
+                return {
+                    'success': False,
+                    'error': 'Login request failed'
+                }
+
+            try:
+                result = login_response.json()
+            except ValueError:
+                # Not JSON, check if we got redirected to game hub
+                return self._check_login_success(username)
+
+            # Check the response for success indicators
+            if result.get('result', {}).get('success') or result.get('success'):
+                user_data = result.get('result', {}).get('user', {})
+                return {
+                    'success': True,
+                    'player_id': user_data.get('playerID'),
+                    'site_user_id': user_data.get('siteUserID'),
+                    'username': username,
+                }
+            else:
+                error_msg = result.get('result', {}).get('error', 'Invalid credentials')
+                return {
+                    'success': False,
+                    'error': error_msg
+                }
+
+        except requests.exceptions.Timeout:
+            logger.error("Timeout connecting to CoN servers")
+            return {
+                'success': False,
+                'error': 'Connection timeout - CoN servers may be slow'
+            }
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Request error during CoN auth: {e}")
+            return {
+                'success': False,
+                'error': 'Could not connect to CoN servers'
+            }
+        except Exception as e:
+            logger.exception(f"Unexpected error during CoN auth: {e}")
+            return {
+                'success': False,
+                'error': 'Authentication service error'
+            }
+
+    def _check_login_success(self, username: str) -> dict:
+        """
+        Check if login was successful by accessing a protected page.
+        """
+        try:
+            # Try to access the game hub which requires authentication
+            hub_response = self.session.get(
+                'https://www.conflictnations.com/index.php?eID=api&key=uberCon&action=getPlayerInfo',
+                timeout=30
+            )
+
+            if hub_response.status_code == 200:
+                try:
+                    data = hub_response.json()
+                    if data.get('result', {}).get('playerID'):
+                        return {
+                            'success': True,
+                            'player_id': data['result']['playerID'],
+                            'site_user_id': data['result'].get('siteUserID'),
+                            'username': username,
+                        }
+                except ValueError:
+                    pass
+
+            return {
+                'success': False,
+                'error': 'Could not verify login'
+            }
+        except Exception as e:
+            logger.error(f"Error checking login success: {e}")
+            return {
+                'success': False,
+                'error': 'Could not verify login'
+            }
+
+    def close(self):
+        """Close the session."""
+        self.session.close()
+
+
+def verify_con_credentials(username: str, password: str) -> dict:
+    """
+    Convenience function to verify CoN credentials.
+    """
+    service = ConAuthService()
+    try:
+        return service.verify_credentials(username, password)
+    finally:
+        service.close()

--- a/Clients/alliance/backend/models.py
+++ b/Clients/alliance/backend/models.py
@@ -1,0 +1,144 @@
+"""
+Database models for the Alliance Dashboard.
+Extends the existing Conlyse database with user authentication and alliance management.
+"""
+from datetime import datetime
+from sqlalchemy import BigInteger, Boolean, Column, Float, ForeignKey, Index, Integer, String, TIMESTAMP, Text
+from sqlalchemy.orm import relationship
+from sqlalchemy.ext.declarative import declarative_base
+from werkzeug.security import generate_password_hash, check_password_hash
+
+Base = declarative_base()
+
+
+class User(Base):
+    """
+    Authenticated user of the alliance dashboard.
+    Linked to a Conflict of Nations player account.
+    """
+    __tablename__ = 'alliance_user'
+
+    user_id = Column(Integer, primary_key=True, autoincrement=True)
+    con_username = Column(String(75), unique=True, nullable=False)  # CoN username
+    con_player_id = Column(BigInteger, nullable=True)  # Linked player_id from player table
+    con_site_user_id = Column(BigInteger, nullable=True)  # CoN site_user_id
+    password_hash = Column(String(256), nullable=False)
+    email = Column(String(255), nullable=True)
+    created_at = Column(TIMESTAMP, default=datetime.utcnow)
+    last_login = Column(TIMESTAMP, nullable=True)
+    is_active = Column(Boolean, default=True)
+
+    # Relationships
+    memberships = relationship('AllianceMembership', back_populates='user', cascade='all, delete-orphan')
+    owned_alliances = relationship('Alliance', back_populates='owner', foreign_keys='Alliance.owner_id')
+
+    def set_password(self, password):
+        """Hash and set the user's password."""
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        """Verify the password against the stored hash."""
+        return check_password_hash(self.password_hash, password)
+
+    def to_dict(self):
+        """Convert user to dictionary for API responses."""
+        return {
+            'user_id': self.user_id,
+            'con_username': self.con_username,
+            'con_player_id': self.con_player_id,
+            'email': self.email,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'last_login': self.last_login.isoformat() if self.last_login else None,
+        }
+
+
+class Alliance(Base):
+    """
+    An alliance is a group of players who play together across multiple games.
+    """
+    __tablename__ = 'alliance'
+
+    alliance_id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(100), unique=True, nullable=False)
+    tag = Column(String(10), unique=True, nullable=False)  # Short tag like [ABC]
+    description = Column(Text, nullable=True)
+    owner_id = Column(Integer, ForeignKey('alliance_user.user_id'), nullable=False)
+    invite_code = Column(String(32), unique=True, nullable=False)  # For joining
+    created_at = Column(TIMESTAMP, default=datetime.utcnow)
+    is_public = Column(Boolean, default=False)  # Whether anyone can join
+
+    # Relationships
+    owner = relationship('User', back_populates='owned_alliances', foreign_keys=[owner_id])
+    members = relationship('AllianceMembership', back_populates='alliance', cascade='all, delete-orphan')
+
+    def to_dict(self, include_members=False):
+        """Convert alliance to dictionary for API responses."""
+        data = {
+            'alliance_id': self.alliance_id,
+            'name': self.name,
+            'tag': self.tag,
+            'description': self.description,
+            'owner_id': self.owner_id,
+            'invite_code': self.invite_code,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'is_public': self.is_public,
+            'member_count': len(self.members) if self.members else 0,
+        }
+        if include_members:
+            data['members'] = [m.to_dict() for m in self.members]
+        return data
+
+
+class AllianceMembership(Base):
+    """
+    Junction table for users belonging to alliances.
+    Users can belong to multiple alliances.
+    """
+    __tablename__ = 'alliance_membership'
+
+    membership_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey('alliance_user.user_id'), nullable=False)
+    alliance_id = Column(Integer, ForeignKey('alliance.alliance_id'), nullable=False)
+    role = Column(String(20), default='member')  # 'owner', 'admin', 'member'
+    joined_at = Column(TIMESTAMP, default=datetime.utcnow)
+
+    # Relationships
+    user = relationship('User', back_populates='memberships')
+    alliance = relationship('Alliance', back_populates='members')
+
+    # Unique constraint - user can only be in an alliance once
+    __table_args__ = (
+        Index('ix_user_alliance', 'user_id', 'alliance_id', unique=True),
+    )
+
+    def to_dict(self):
+        """Convert membership to dictionary for API responses."""
+        return {
+            'membership_id': self.membership_id,
+            'user_id': self.user_id,
+            'alliance_id': self.alliance_id,
+            'role': self.role,
+            'joined_at': self.joined_at.isoformat() if self.joined_at else None,
+            'user': {
+                'user_id': self.user.user_id,
+                'con_username': self.user.con_username,
+            } if self.user else None,
+        }
+
+
+class WatchedGame(Base):
+    """
+    Games that an alliance is tracking/watching together.
+    """
+    __tablename__ = 'alliance_watched_game'
+
+    watched_id = Column(Integer, primary_key=True, autoincrement=True)
+    alliance_id = Column(Integer, ForeignKey('alliance.alliance_id'), nullable=False)
+    game_id = Column(Integer, nullable=False)  # References game.game_id
+    added_by = Column(Integer, ForeignKey('alliance_user.user_id'), nullable=False)
+    added_at = Column(TIMESTAMP, default=datetime.utcnow)
+    notes = Column(Text, nullable=True)
+
+    __table_args__ = (
+        Index('ix_alliance_game', 'alliance_id', 'game_id', unique=True),
+    )

--- a/Clients/alliance/backend/requirements.txt
+++ b/Clients/alliance/backend/requirements.txt
@@ -1,0 +1,12 @@
+Flask==2.3.3
+Flask-CORS==4.0.0
+Flask-Compress==1.14
+Flask-SQLAlchemy==3.1.1
+SQLAlchemy==2.0.23
+mysql-connector-python==8.2.0
+python-dotenv==1.0.0
+PyJWT==2.8.0
+Werkzeug==3.0.1
+requests==2.31.0
+beautifulsoup4==4.12.2
+gunicorn==21.2.0

--- a/Clients/alliance/docker-compose.external-db.yml
+++ b/Clients/alliance/docker-compose.external-db.yml
@@ -1,0 +1,49 @@
+version: '3.8'
+
+# Use this file when connecting to an EXISTING Conlyse database
+# Run with: docker-compose -f docker-compose.external-db.yml up -d
+
+services:
+  # Backend API
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: conlyse-alliance-backend
+    restart: unless-stopped
+    environment:
+      - FLASK_SECRET=${FLASK_SECRET:-your-flask-secret-key}
+      - JWT_SECRET=${JWT_SECRET:-your-jwt-secret-key}
+      - JWT_EXPIRATION_HOURS=${JWT_EXPIRATION_HOURS:-24}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_USER_PASSWORD=${MYSQL_USER_PASSWORD}
+      - MYSQL_IP_ADDR=${MYSQL_IP_ADDR}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - API_PORT=5000
+      - DEBUG=${DEBUG:-false}
+      - CORS_ORIGINS=${CORS_ORIGINS:-*}
+    ports:
+      - "5000:5000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # Frontend
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        - REACT_APP_API_URL=/api
+    container_name: conlyse-alliance-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "80:80"
+
+networks:
+  default:
+    name: conlyse-alliance-network

--- a/Clients/alliance/docker-compose.yml
+++ b/Clients/alliance/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '3.8'
+
+services:
+  # MySQL Database
+  db:
+    image: mysql:8.0
+    container_name: conlyse-alliance-db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpassword}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-conlyse}
+      MYSQL_USER: ${MYSQL_USER:-conlyse}
+      MYSQL_PASSWORD: ${MYSQL_USER_PASSWORD:-conlysepassword}
+    volumes:
+      - mysql_data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Backend API
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: conlyse-alliance-backend
+    restart: unless-stopped
+    environment:
+      - FLASK_SECRET=${FLASK_SECRET:-your-flask-secret-key}
+      - JWT_SECRET=${JWT_SECRET:-your-jwt-secret-key}
+      - JWT_EXPIRATION_HOURS=${JWT_EXPIRATION_HOURS:-24}
+      - MYSQL_USER=${MYSQL_USER:-conlyse}
+      - MYSQL_USER_PASSWORD=${MYSQL_USER_PASSWORD:-conlysepassword}
+      - MYSQL_IP_ADDR=db
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-conlyse}
+      - API_PORT=5000
+      - DEBUG=${DEBUG:-false}
+      - CORS_ORIGINS=${CORS_ORIGINS:-*}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "5000:5000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # Frontend
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        - REACT_APP_API_URL=/api
+    container_name: conlyse-alliance-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "80:80"
+
+volumes:
+  mysql_data:
+
+networks:
+  default:
+    name: conlyse-alliance-network

--- a/Clients/alliance/frontend/.gitignore
+++ b/Clients/alliance/frontend/.gitignore
@@ -1,0 +1,21 @@
+# Dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# Testing
+/coverage
+
+# Production
+/build
+
+# Misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/Clients/alliance/frontend/Dockerfile
+++ b/Clients/alliance/frontend/Dockerfile
@@ -1,0 +1,36 @@
+# Frontend Dockerfile - Multi-stage build
+
+# Build stage
+FROM node:18-alpine as build
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci --silent
+
+# Copy source code
+COPY . .
+
+# Build argument for API URL
+ARG REACT_APP_API_URL=/api
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+
+# Copy custom nginx config
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy built files from build stage
+COPY --from=build /app/build /usr/share/nginx/html
+
+# Expose port
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Clients/alliance/frontend/nginx.conf
+++ b/Clients/alliance/frontend/nginx.conf
@@ -1,0 +1,41 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_min_length 1000;
+
+    # Handle React Router - serve index.html for all routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy API requests to backend
+    location /api {
+        proxy_pass http://backend:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 120s;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+}

--- a/Clients/alliance/frontend/package.json
+++ b/Clients/alliance/frontend/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "conlyse-alliance-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.18",
+    "@mui/material": "^5.14.18",
+    "axios": "^1.6.2",
+    "date-fns": "^2.30.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-query": "^3.39.3",
+    "react-router-dom": "^6.20.1",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/Clients/alliance/frontend/public/index.html
+++ b/Clients/alliance/frontend/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#1976d2" />
+    <meta name="description" content="Conlyse Alliance Dashboard - Track your Conflict of Nations games with your alliance" />
+    <title>Conlyse Alliance Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/Clients/alliance/frontend/src/App.js
+++ b/Clients/alliance/frontend/src/App.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { AuthProvider } from './context/AuthContext';
+import ProtectedRoute from './components/ProtectedRoute';
+import Layout from './components/Layout';
+
+import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
+import DashboardPage from './pages/DashboardPage';
+import AlliancesPage from './pages/AlliancesPage';
+import AllianceDetailPage from './pages/AllianceDetailPage';
+
+// Create dark theme
+const theme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#90caf9',
+    },
+    secondary: {
+      main: '#f48fb1',
+    },
+    background: {
+      default: '#0a1929',
+      paper: '#0d2137',
+    },
+  },
+  typography: {
+    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+  },
+  components: {
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+        },
+      },
+    },
+  },
+});
+
+// Create React Query client
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      cacheTime: 10 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    },
+  },
+});
+
+function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <Router>
+            <Routes>
+              {/* Public routes */}
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/register" element={<RegisterPage />} />
+
+              {/* Protected routes with layout */}
+              <Route
+                path="/dashboard"
+                element={
+                  <ProtectedRoute>
+                    <Layout>
+                      <DashboardPage />
+                    </Layout>
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/alliances"
+                element={
+                  <ProtectedRoute>
+                    <Layout>
+                      <AlliancesPage />
+                    </Layout>
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/alliances/:allianceId"
+                element={
+                  <ProtectedRoute>
+                    <Layout>
+                      <AllianceDetailPage />
+                    </Layout>
+                  </ProtectedRoute>
+                }
+              />
+
+              {/* Default redirect */}
+              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              <Route path="*" element={<Navigate to="/dashboard" replace />} />
+            </Routes>
+          </Router>
+        </AuthProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
+  );
+}
+
+export default App;

--- a/Clients/alliance/frontend/src/api/index.js
+++ b/Clients/alliance/frontend/src/api/index.js
@@ -1,0 +1,64 @@
+import axios from 'axios';
+
+// API base URL - configurable via environment variable
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
+
+// Create axios instance
+const api = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// Add auth token to requests
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// Handle auth errors
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  }
+);
+
+// Auth API
+export const authAPI = {
+  register: (data) => api.post('/auth/register', data),
+  login: (data) => api.post('/auth/login', data),
+  getMe: () => api.get('/auth/me'),
+  refreshToken: () => api.post('/auth/refresh'),
+};
+
+// Alliance API
+export const allianceAPI = {
+  list: () => api.get('/alliances'),
+  get: (id) => api.get(`/alliances/${id}`),
+  create: (data) => api.post('/alliances', data),
+  join: (inviteCode) => api.post('/alliances/join', { invite_code: inviteCode }),
+  leave: (id) => api.post(`/alliances/${id}/leave`),
+  regenerateInvite: (id) => api.post(`/alliances/${id}/regenerate-invite`),
+};
+
+// Dashboard API
+export const dashboardAPI = {
+  getMyGames: () => api.get('/dashboard/my-games'),
+  getMyStats: (gameId) => api.get(`/dashboard/my-stats/${gameId}`),
+  getAllianceGames: (allianceId) => api.get(`/dashboard/alliance/${allianceId}/games`),
+};
+
+// Health check
+export const healthCheck = () => api.get('/health');
+
+export default api;

--- a/Clients/alliance/frontend/src/components/Layout.js
+++ b/Clients/alliance/frontend/src/components/Layout.js
@@ -1,0 +1,184 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  Box,
+  AppBar,
+  Toolbar,
+  Typography,
+  IconButton,
+  Drawer,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  ListItemButton,
+  Divider,
+  Avatar,
+  Menu,
+  MenuItem,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material';
+import {
+  Menu as MenuIcon,
+  Dashboard as DashboardIcon,
+  Groups as GroupsIcon,
+  Logout as LogoutIcon,
+  Person as PersonIcon,
+} from '@mui/icons-material';
+import { useAuth } from '../context/AuthContext';
+
+const drawerWidth = 240;
+
+const Layout = ({ children }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user, logout } = useAuth();
+
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  const handleMenuOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleLogout = () => {
+    handleMenuClose();
+    logout();
+    navigate('/login');
+  };
+
+  const menuItems = [
+    { text: 'Dashboard', icon: <DashboardIcon />, path: '/dashboard' },
+    { text: 'Alliances', icon: <GroupsIcon />, path: '/alliances' },
+  ];
+
+  const drawer = (
+    <Box>
+      <Toolbar>
+        <Typography variant="h6" noWrap component="div" color="primary">
+          Conlyse
+        </Typography>
+      </Toolbar>
+      <Divider />
+      <List>
+        {menuItems.map((item) => (
+          <ListItem key={item.text} disablePadding>
+            <ListItemButton
+              selected={location.pathname === item.path}
+              onClick={() => {
+                navigate(item.path);
+                if (isMobile) setMobileOpen(false);
+              }}
+            >
+              <ListItemIcon>{item.icon}</ListItemIcon>
+              <ListItemText primary={item.text} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <AppBar
+        position="fixed"
+        sx={{
+          width: { md: `calc(100% - ${drawerWidth}px)` },
+          ml: { md: `${drawerWidth}px` },
+        }}
+      >
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            edge="start"
+            onClick={handleDrawerToggle}
+            sx={{ mr: 2, display: { md: 'none' } }}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
+            Alliance Dashboard
+          </Typography>
+          <IconButton color="inherit" onClick={handleMenuOpen}>
+            <Avatar sx={{ width: 32, height: 32, bgcolor: 'secondary.main' }}>
+              {user?.con_username?.charAt(0).toUpperCase()}
+            </Avatar>
+          </IconButton>
+          <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={handleMenuClose}
+          >
+            <MenuItem disabled>
+              <PersonIcon sx={{ mr: 1 }} />
+              {user?.con_username}
+            </MenuItem>
+            <Divider />
+            <MenuItem onClick={handleLogout}>
+              <LogoutIcon sx={{ mr: 1 }} />
+              Logout
+            </MenuItem>
+          </Menu>
+        </Toolbar>
+      </AppBar>
+
+      <Box
+        component="nav"
+        sx={{ width: { md: drawerWidth }, flexShrink: { md: 0 } }}
+      >
+        {/* Mobile drawer */}
+        <Drawer
+          variant="temporary"
+          open={mobileOpen}
+          onClose={handleDrawerToggle}
+          ModalProps={{ keepMounted: true }}
+          sx={{
+            display: { xs: 'block', md: 'none' },
+            '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+          }}
+        >
+          {drawer}
+        </Drawer>
+
+        {/* Desktop drawer */}
+        <Drawer
+          variant="permanent"
+          sx={{
+            display: { xs: 'none', md: 'block' },
+            '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+          }}
+          open
+        >
+          {drawer}
+        </Drawer>
+      </Box>
+
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          width: { md: `calc(100% - ${drawerWidth}px)` },
+          minHeight: '100vh',
+          bgcolor: 'background.default',
+        }}
+      >
+        <Toolbar />
+        {children}
+      </Box>
+    </Box>
+  );
+};
+
+export default Layout;

--- a/Clients/alliance/frontend/src/components/ProtectedRoute.js
+++ b/Clients/alliance/frontend/src/components/ProtectedRoute.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { Box, CircularProgress } from '@mui/material';
+
+const ProtectedRoute = ({ children }) => {
+  const { isAuthenticated, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="100vh"
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/Clients/alliance/frontend/src/context/AuthContext.js
+++ b/Clients/alliance/frontend/src/context/AuthContext.js
@@ -1,0 +1,118 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import { authAPI } from '../api';
+
+const AuthContext = createContext(null);
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [alliances, setAlliances] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Check for existing session on mount
+  useEffect(() => {
+    const checkAuth = async () => {
+      const token = localStorage.getItem('token');
+      if (token) {
+        try {
+          const response = await authAPI.getMe();
+          setUser(response.data.user);
+          setAlliances(response.data.alliances || []);
+        } catch (err) {
+          localStorage.removeItem('token');
+          localStorage.removeItem('user');
+        }
+      }
+      setLoading(false);
+    };
+    checkAuth();
+  }, []);
+
+  const login = useCallback(async (conUsername, password) => {
+    setError(null);
+    try {
+      const response = await authAPI.login({ con_username: conUsername, password });
+      const { token, user: userData } = response.data;
+      localStorage.setItem('token', token);
+      localStorage.setItem('user', JSON.stringify(userData));
+      setUser(userData);
+
+      // Fetch alliances
+      const meResponse = await authAPI.getMe();
+      setAlliances(meResponse.data.alliances || []);
+
+      return { success: true };
+    } catch (err) {
+      const message = err.response?.data?.error || 'Login failed';
+      setError(message);
+      return { success: false, error: message };
+    }
+  }, []);
+
+  const register = useCallback(async (conUsername, conPassword, dashboardPassword, email) => {
+    setError(null);
+    try {
+      const response = await authAPI.register({
+        con_username: conUsername,
+        con_password: conPassword,
+        dashboard_password: dashboardPassword,
+        email: email || undefined,
+      });
+      const { token, user: userData } = response.data;
+      localStorage.setItem('token', token);
+      localStorage.setItem('user', JSON.stringify(userData));
+      setUser(userData);
+      setAlliances([]);
+      return { success: true };
+    } catch (err) {
+      const message = err.response?.data?.error || 'Registration failed';
+      setError(message);
+      return { success: false, error: message };
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    setUser(null);
+    setAlliances([]);
+  }, []);
+
+  const refreshUser = useCallback(async () => {
+    try {
+      const response = await authAPI.getMe();
+      setUser(response.data.user);
+      setAlliances(response.data.alliances || []);
+    } catch (err) {
+      console.error('Failed to refresh user data:', err);
+    }
+  }, []);
+
+  const value = {
+    user,
+    alliances,
+    loading,
+    error,
+    isAuthenticated: !!user,
+    login,
+    register,
+    logout,
+    refreshUser,
+  };
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthContext;

--- a/Clients/alliance/frontend/src/index.js
+++ b/Clients/alliance/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/Clients/alliance/frontend/src/pages/AllianceDetailPage.js
+++ b/Clients/alliance/frontend/src/pages/AllianceDetailPage.js
@@ -1,0 +1,366 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Container,
+  Typography,
+  Card,
+  CardContent,
+  Grid,
+  Button,
+  IconButton,
+  Chip,
+  Alert,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Tooltip,
+  Divider,
+} from '@mui/material';
+import {
+  ArrowBack as BackIcon,
+  ContentCopy as CopyIcon,
+  Refresh as RefreshIcon,
+  ExitToApp as LeaveIcon,
+} from '@mui/icons-material';
+import { useAuth } from '../context/AuthContext';
+import { allianceAPI, dashboardAPI } from '../api';
+
+const AllianceDetailPage = () => {
+  const { allianceId } = useParams();
+  const navigate = useNavigate();
+  const { user, refreshUser } = useAuth();
+
+  const [alliance, setAlliance] = useState(null);
+  const [myRole, setMyRole] = useState(null);
+  const [games, setGames] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
+  const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
+  const [copiedInvite, setCopiedInvite] = useState(false);
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [allianceResponse, gamesResponse] = await Promise.all([
+        allianceAPI.get(allianceId),
+        dashboardAPI.getAllianceGames(allianceId),
+      ]);
+      setAlliance(allianceResponse.data.alliance);
+      setMyRole(allianceResponse.data.my_role);
+      setGames(gamesResponse.data.games || []);
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to load alliance data');
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [allianceId]);
+
+  const handleCopyInvite = () => {
+    navigator.clipboard.writeText(alliance.invite_code);
+    setCopiedInvite(true);
+    setTimeout(() => setCopiedInvite(false), 2000);
+  };
+
+  const handleRegenerateInvite = async () => {
+    try {
+      const response = await allianceAPI.regenerateInvite(allianceId);
+      setAlliance({ ...alliance, invite_code: response.data.invite_code });
+      setSuccess('Invite code regenerated');
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to regenerate invite code');
+    }
+  };
+
+  const handleLeave = async () => {
+    try {
+      await allianceAPI.leave(allianceId);
+      await refreshUser();
+      navigate('/alliances');
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to leave alliance');
+    }
+    setLeaveDialogOpen(false);
+  };
+
+  const formatDate = (timestamp) => {
+    if (!timestamp) return 'N/A';
+    return new Date(timestamp * 1000).toLocaleDateString();
+  };
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="50vh">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!alliance) {
+    return (
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Alert severity="error">Alliance not found</Alert>
+      </Container>
+    );
+  }
+
+  const activeGames = games.filter(g => g.is_active);
+  const isAdmin = myRole === 'owner' || myRole === 'admin';
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      {/* Header */}
+      <Box display="flex" alignItems="center" gap={2} mb={4}>
+        <IconButton onClick={() => navigate('/alliances')}>
+          <BackIcon />
+        </IconButton>
+        <Box flex={1}>
+          <Box display="flex" alignItems="center" gap={1}>
+            <Chip label={alliance.tag} color="primary" />
+            <Typography variant="h4" component="h1">
+              {alliance.name}
+            </Typography>
+          </Box>
+          {alliance.description && (
+            <Typography variant="body1" color="textSecondary">
+              {alliance.description}
+            </Typography>
+          )}
+        </Box>
+        <Tooltip title="Refresh">
+          <IconButton onClick={fetchData}>
+            <RefreshIcon />
+          </IconButton>
+        </Tooltip>
+        {myRole !== 'owner' && (
+          <Button
+            color="error"
+            startIcon={<LeaveIcon />}
+            onClick={() => setLeaveDialogOpen(true)}
+          >
+            Leave
+          </Button>
+        )}
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 3 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {success && (
+        <Alert severity="success" sx={{ mb: 3 }} onClose={() => setSuccess(null)}>
+          {success}
+        </Alert>
+      )}
+
+      <Grid container spacing={3}>
+        {/* Invite Code Card */}
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Invite Code
+              </Typography>
+              <Box display="flex" alignItems="center" gap={1}>
+                <TextField
+                  value={alliance.invite_code}
+                  InputProps={{ readOnly: true }}
+                  size="small"
+                  fullWidth
+                />
+                <Tooltip title={copiedInvite ? 'Copied!' : 'Copy'}>
+                  <IconButton onClick={handleCopyInvite}>
+                    <CopyIcon />
+                  </IconButton>
+                </Tooltip>
+              </Box>
+              {isAdmin && (
+                <Button
+                  size="small"
+                  onClick={handleRegenerateInvite}
+                  sx={{ mt: 1 }}
+                >
+                  Regenerate Code
+                </Button>
+              )}
+              <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
+                Share this code with players you want to invite
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Stats Card */}
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Alliance Stats
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={6}>
+                  <Typography variant="h4" color="primary">
+                    {alliance.members?.length || 0}
+                  </Typography>
+                  <Typography variant="body2" color="textSecondary">
+                    Members
+                  </Typography>
+                </Grid>
+                <Grid item xs={6}>
+                  <Typography variant="h4" color="primary">
+                    {activeGames.length}
+                  </Typography>
+                  <Typography variant="body2" color="textSecondary">
+                    Active Games
+                  </Typography>
+                </Grid>
+              </Grid>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Members List */}
+        <Grid item xs={12}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Members
+              </Typography>
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Player</TableCell>
+                      <TableCell>Role</TableCell>
+                      <TableCell>Joined</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {alliance.members?.map((member) => (
+                      <TableRow key={member.membership_id}>
+                        <TableCell>
+                          {member.user?.con_username}
+                          {member.user?.user_id === user?.user_id && (
+                            <Chip label="You" size="small" sx={{ ml: 1 }} />
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            label={member.role}
+                            size="small"
+                            color={member.role === 'owner' ? 'warning' : 'default'}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          {member.joined_at
+                            ? new Date(member.joined_at).toLocaleDateString()
+                            : 'N/A'}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Active Games */}
+        <Grid item xs={12}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Alliance Games ({activeGames.length} active)
+              </Typography>
+              {activeGames.length === 0 ? (
+                <Typography variant="body2" color="textSecondary">
+                  No active games found for alliance members
+                </Typography>
+              ) : (
+                <TableContainer>
+                  <Table>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Game ID</TableCell>
+                        <TableCell>Scenario</TableCell>
+                        <TableCell>Members Playing</TableCell>
+                        <TableCell>Started</TableCell>
+                        <TableCell>Speed</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {activeGames.map((game) => (
+                        <TableRow
+                          key={game.game_id}
+                          hover
+                          sx={{ cursor: 'pointer' }}
+                          onClick={() => window.open(`/game/${game.game_id}/dashboard`, '_blank')}
+                        >
+                          <TableCell>{game.game_id}</TableCell>
+                          <TableCell>{game.scenario_name}</TableCell>
+                          <TableCell>
+                            {game.members?.map((m, i) => (
+                              <Chip
+                                key={i}
+                                label={m.player_name}
+                                size="small"
+                                sx={{ mr: 0.5, mb: 0.5 }}
+                              />
+                            ))}
+                          </TableCell>
+                          <TableCell>{formatDate(game.start_time)}</TableCell>
+                          <TableCell>
+                            <Chip
+                              label={`${game.speed}x`}
+                              size="small"
+                              color={game.speed === 4 ? 'warning' : 'default'}
+                            />
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      {/* Leave Dialog */}
+      <Dialog open={leaveDialogOpen} onClose={() => setLeaveDialogOpen(false)}>
+        <DialogTitle>Leave Alliance</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to leave {alliance.name}?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setLeaveDialogOpen(false)}>Cancel</Button>
+          <Button onClick={handleLeave} color="error">
+            Leave
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Container>
+  );
+};
+
+export default AllianceDetailPage;

--- a/Clients/alliance/frontend/src/pages/AlliancesPage.js
+++ b/Clients/alliance/frontend/src/pages/AlliancesPage.js
@@ -1,0 +1,287 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Container,
+  Typography,
+  Card,
+  CardContent,
+  CardActions,
+  Grid,
+  Button,
+  TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Alert,
+  CircularProgress,
+  Chip,
+  IconButton,
+  Tooltip,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  GroupAdd as JoinIcon,
+  ArrowBack as BackIcon,
+} from '@mui/icons-material';
+import { useAuth } from '../context/AuthContext';
+import { allianceAPI } from '../api';
+
+const AlliancesPage = () => {
+  const navigate = useNavigate();
+  const { alliances, refreshUser } = useAuth();
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [joinDialogOpen, setJoinDialogOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
+
+  // Create alliance form
+  const [createForm, setCreateForm] = useState({
+    name: '',
+    tag: '',
+    description: '',
+  });
+
+  // Join alliance form
+  const [inviteCode, setInviteCode] = useState('');
+
+  const handleCreateAlliance = async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      await allianceAPI.create(createForm);
+      setSuccess('Alliance created successfully!');
+      setCreateDialogOpen(false);
+      setCreateForm({ name: '', tag: '', description: '' });
+      await refreshUser();
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to create alliance');
+    }
+    setLoading(false);
+  };
+
+  const handleJoinAlliance = async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      await allianceAPI.join(inviteCode);
+      setSuccess('Successfully joined alliance!');
+      setJoinDialogOpen(false);
+      setInviteCode('');
+      await refreshUser();
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to join alliance');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      {/* Header */}
+      <Box display="flex" alignItems="center" gap={2} mb={4}>
+        <IconButton onClick={() => navigate('/dashboard')}>
+          <BackIcon />
+        </IconButton>
+        <Box flex={1}>
+          <Typography variant="h4" component="h1">
+            Your Alliances
+          </Typography>
+          <Typography variant="body1" color="textSecondary">
+            Manage your alliance memberships
+          </Typography>
+        </Box>
+        <Button
+          variant="outlined"
+          startIcon={<JoinIcon />}
+          onClick={() => setJoinDialogOpen(true)}
+        >
+          Join Alliance
+        </Button>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => setCreateDialogOpen(true)}
+        >
+          Create Alliance
+        </Button>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 3 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {success && (
+        <Alert severity="success" sx={{ mb: 3 }} onClose={() => setSuccess(null)}>
+          {success}
+        </Alert>
+      )}
+
+      {/* Alliance List */}
+      {alliances.length === 0 ? (
+        <Card>
+          <CardContent sx={{ textAlign: 'center', py: 6 }}>
+            <Typography variant="h6" color="textSecondary" gutterBottom>
+              You're not a member of any alliances yet
+            </Typography>
+            <Typography variant="body2" color="textSecondary" sx={{ mb: 3 }}>
+              Create a new alliance or join an existing one with an invite code
+            </Typography>
+            <Box display="flex" gap={2} justifyContent="center">
+              <Button
+                variant="outlined"
+                startIcon={<JoinIcon />}
+                onClick={() => setJoinDialogOpen(true)}
+              >
+                Join Alliance
+              </Button>
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={() => setCreateDialogOpen(true)}
+              >
+                Create Alliance
+              </Button>
+            </Box>
+          </CardContent>
+        </Card>
+      ) : (
+        <Grid container spacing={3}>
+          {alliances.map((alliance) => (
+            <Grid item xs={12} sm={6} md={4} key={alliance.alliance_id}>
+              <Card
+                sx={{
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  cursor: 'pointer',
+                  '&:hover': { boxShadow: 6 },
+                }}
+                onClick={() => navigate(`/alliances/${alliance.alliance_id}`)}
+              >
+                <CardContent sx={{ flex: 1 }}>
+                  <Box display="flex" alignItems="center" gap={1} mb={1}>
+                    <Chip
+                      label={alliance.tag}
+                      color="primary"
+                      size="small"
+                    />
+                    <Chip
+                      label={alliance.role}
+                      variant="outlined"
+                      size="small"
+                      color={alliance.role === 'owner' ? 'warning' : 'default'}
+                    />
+                  </Box>
+                  <Typography variant="h6" gutterBottom>
+                    {alliance.name}
+                  </Typography>
+                  {alliance.description && (
+                    <Typography variant="body2" color="textSecondary">
+                      {alliance.description}
+                    </Typography>
+                  )}
+                  <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
+                    {alliance.member_count} member{alliance.member_count !== 1 ? 's' : ''}
+                  </Typography>
+                </CardContent>
+                <CardActions>
+                  <Button size="small" color="primary">
+                    View Details
+                  </Button>
+                </CardActions>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
+
+      {/* Create Alliance Dialog */}
+      <Dialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Create New Alliance</DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            label="Alliance Name"
+            value={createForm.name}
+            onChange={(e) => setCreateForm({ ...createForm, name: e.target.value })}
+            margin="normal"
+            required
+          />
+          <TextField
+            fullWidth
+            label="Tag (e.g., ABC)"
+            value={createForm.tag}
+            onChange={(e) => setCreateForm({ ...createForm, tag: e.target.value.toUpperCase() })}
+            margin="normal"
+            required
+            inputProps={{ maxLength: 10 }}
+            helperText="Short identifier shown in brackets, e.g., [ABC]"
+          />
+          <TextField
+            fullWidth
+            label="Description (optional)"
+            value={createForm.description}
+            onChange={(e) => setCreateForm({ ...createForm, description: e.target.value })}
+            margin="normal"
+            multiline
+            rows={3}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateDialogOpen(false)}>Cancel</Button>
+          <Button
+            onClick={handleCreateAlliance}
+            variant="contained"
+            disabled={loading || !createForm.name || !createForm.tag}
+          >
+            {loading ? <CircularProgress size={24} /> : 'Create'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Join Alliance Dialog */}
+      <Dialog
+        open={joinDialogOpen}
+        onClose={() => setJoinDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Join Alliance</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="textSecondary" sx={{ mb: 2 }}>
+            Enter the invite code provided by an alliance admin
+          </Typography>
+          <TextField
+            fullWidth
+            label="Invite Code"
+            value={inviteCode}
+            onChange={(e) => setInviteCode(e.target.value)}
+            margin="normal"
+            required
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setJoinDialogOpen(false)}>Cancel</Button>
+          <Button
+            onClick={handleJoinAlliance}
+            variant="contained"
+            disabled={loading || !inviteCode}
+          >
+            {loading ? <CircularProgress size={24} /> : 'Join'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Container>
+  );
+};
+
+export default AlliancesPage;

--- a/Clients/alliance/frontend/src/pages/DashboardPage.js
+++ b/Clients/alliance/frontend/src/pages/DashboardPage.js
@@ -1,0 +1,295 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Container,
+  Typography,
+  Card,
+  CardContent,
+  Grid,
+  Chip,
+  Button,
+  CircularProgress,
+  Alert,
+  IconButton,
+  Tooltip,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import {
+  Refresh as RefreshIcon,
+  Groups as GroupsIcon,
+  SportsEsports as GameIcon,
+  TrendingUp as TrendingUpIcon,
+  EmojiEvents as TrophyIcon,
+} from '@mui/icons-material';
+import { useAuth } from '../context/AuthContext';
+import { dashboardAPI } from '../api';
+
+const DashboardPage = () => {
+  const navigate = useNavigate();
+  const { user, alliances } = useAuth();
+  const [games, setGames] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [stats, setStats] = useState({});
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const gamesResponse = await dashboardAPI.getMyGames();
+      const gamesData = gamesResponse.data.games || [];
+      setGames(gamesData);
+
+      // Fetch stats for active games
+      const activeGames = gamesData.filter(g => g.is_active);
+      const statsPromises = activeGames.slice(0, 5).map(async (game) => {
+        try {
+          const statsResponse = await dashboardAPI.getMyStats(game.game_id);
+          return { gameId: game.game_id, ...statsResponse.data };
+        } catch (err) {
+          return { gameId: game.game_id, error: true };
+        }
+      });
+      const statsResults = await Promise.all(statsPromises);
+      const statsMap = {};
+      statsResults.forEach(s => { statsMap[s.gameId] = s; });
+      setStats(statsMap);
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to load dashboard data');
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const formatDate = (timestamp) => {
+    if (!timestamp) return 'N/A';
+    return new Date(timestamp * 1000).toLocaleDateString();
+  };
+
+  const activeGames = games.filter(g => g.is_active);
+  const completedGames = games.filter(g => !g.is_active);
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      {/* Header */}
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={4}>
+        <Box>
+          <Typography variant="h4" component="h1">
+            Welcome, {user?.con_username}
+          </Typography>
+          <Typography variant="body1" color="textSecondary">
+            Your personal Conflict of Nations dashboard
+          </Typography>
+        </Box>
+        <Tooltip title="Refresh data">
+          <IconButton onClick={fetchData} disabled={loading}>
+            <RefreshIcon />
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Stats Cards */}
+      <Grid container spacing={3} sx={{ mb: 4 }}>
+        <Grid item xs={12} sm={6} md={3}>
+          <Card>
+            <CardContent>
+              <Box display="flex" alignItems="center" gap={1}>
+                <GameIcon color="primary" />
+                <Typography variant="h6">{activeGames.length}</Typography>
+              </Box>
+              <Typography variant="body2" color="textSecondary">
+                Active Games
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} sm={6} md={3}>
+          <Card>
+            <CardContent>
+              <Box display="flex" alignItems="center" gap={1}>
+                <TrophyIcon color="warning" />
+                <Typography variant="h6">{completedGames.length}</Typography>
+              </Box>
+              <Typography variant="body2" color="textSecondary">
+                Completed Games
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} sm={6} md={3}>
+          <Card>
+            <CardContent>
+              <Box display="flex" alignItems="center" gap={1}>
+                <GroupsIcon color="secondary" />
+                <Typography variant="h6">{alliances.length}</Typography>
+              </Box>
+              <Typography variant="body2" color="textSecondary">
+                Alliances
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} sm={6} md={3}>
+          <Card sx={{ cursor: 'pointer' }} onClick={() => navigate('/alliances')}>
+            <CardContent>
+              <Box display="flex" alignItems="center" gap={1}>
+                <TrendingUpIcon color="success" />
+                <Typography variant="h6">View</Typography>
+              </Box>
+              <Typography variant="body2" color="textSecondary">
+                Alliance Dashboard
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      {/* Alliances Quick View */}
+      {alliances.length > 0 && (
+        <Card sx={{ mb: 4 }}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              Your Alliances
+            </Typography>
+            <Box display="flex" gap={1} flexWrap="wrap">
+              {alliances.map((alliance) => (
+                <Chip
+                  key={alliance.alliance_id}
+                  label={`[${alliance.tag}] ${alliance.name}`}
+                  color="primary"
+                  variant="outlined"
+                  onClick={() => navigate(`/alliances/${alliance.alliance_id}`)}
+                />
+              ))}
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={() => navigate('/alliances')}
+              >
+                Manage Alliances
+              </Button>
+            </Box>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Active Games */}
+      <Typography variant="h5" gutterBottom sx={{ mt: 4 }}>
+        Active Games
+      </Typography>
+
+      {loading ? (
+        <Box display="flex" justifyContent="center" py={4}>
+          <CircularProgress />
+        </Box>
+      ) : activeGames.length === 0 ? (
+        <Alert severity="info">
+          No active games found. Games you join will appear here once they're being tracked.
+        </Alert>
+      ) : (
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Game ID</TableCell>
+                <TableCell>Scenario</TableCell>
+                <TableCell>Country</TableCell>
+                <TableCell>Victory Points</TableCell>
+                <TableCell>Provinces</TableCell>
+                <TableCell>Started</TableCell>
+                <TableCell>Speed</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {activeGames.map((game) => {
+                const gameStats = stats[game.game_id];
+                return (
+                  <TableRow
+                    key={game.game_id}
+                    hover
+                    sx={{ cursor: 'pointer' }}
+                    onClick={() => window.open(`/game/${game.game_id}/dashboard`, '_blank')}
+                  >
+                    <TableCell>{game.game_id}</TableCell>
+                    <TableCell>{game.scenario_name}</TableCell>
+                    <TableCell>{game.country_name || 'Unknown'}</TableCell>
+                    <TableCell>
+                      {gameStats?.stats?.victory_points ?? '-'}
+                    </TableCell>
+                    <TableCell>
+                      {gameStats?.stats?.province_count ?? '-'}
+                    </TableCell>
+                    <TableCell>{formatDate(game.start_time)}</TableCell>
+                    <TableCell>
+                      <Chip
+                        label={`${game.speed}x`}
+                        size="small"
+                        color={game.speed === 4 ? 'warning' : 'default'}
+                      />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      {/* Completed Games */}
+      {completedGames.length > 0 && (
+        <>
+          <Typography variant="h5" gutterBottom sx={{ mt: 4 }}>
+            Completed Games
+          </Typography>
+          <TableContainer component={Paper}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Game ID</TableCell>
+                  <TableCell>Scenario</TableCell>
+                  <TableCell>Country</TableCell>
+                  <TableCell>Started</TableCell>
+                  <TableCell>Ended</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {completedGames.slice(0, 10).map((game) => (
+                  <TableRow
+                    key={game.game_id}
+                    hover
+                    sx={{ cursor: 'pointer' }}
+                    onClick={() => window.open(`/game/${game.game_id}/dashboard`, '_blank')}
+                  >
+                    <TableCell>{game.game_id}</TableCell>
+                    <TableCell>{game.scenario_name}</TableCell>
+                    <TableCell>{game.country_name || 'Unknown'}</TableCell>
+                    <TableCell>{formatDate(game.start_time)}</TableCell>
+                    <TableCell>{formatDate(game.end_time)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default DashboardPage;

--- a/Clients/alliance/frontend/src/pages/LoginPage.js
+++ b/Clients/alliance/frontend/src/pages/LoginPage.js
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import {
+  Box,
+  Card,
+  CardContent,
+  TextField,
+  Button,
+  Typography,
+  Alert,
+  Link,
+  CircularProgress,
+  Container,
+} from '@mui/material';
+import { useAuth } from '../context/AuthContext';
+
+const LoginPage = () => {
+  const navigate = useNavigate();
+  const { login, error } = useAuth();
+  const [formData, setFormData] = useState({
+    conUsername: '',
+    password: '',
+  });
+  const [loading, setLoading] = useState(false);
+  const [localError, setLocalError] = useState('');
+
+  const handleChange = (e) => {
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLocalError('');
+    setLoading(true);
+
+    const result = await login(formData.conUsername, formData.password);
+    setLoading(false);
+
+    if (result.success) {
+      navigate('/dashboard');
+    } else {
+      setLocalError(result.error);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        minHeight="100vh"
+        py={4}
+      >
+        <Typography variant="h3" component="h1" gutterBottom color="primary">
+          Conlyse
+        </Typography>
+        <Typography variant="h6" color="textSecondary" gutterBottom>
+          Alliance Dashboard
+        </Typography>
+
+        <Card sx={{ width: '100%', mt: 4 }}>
+          <CardContent sx={{ p: 4 }}>
+            <Typography variant="h5" component="h2" gutterBottom align="center">
+              Sign In
+            </Typography>
+
+            {(localError || error) && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {localError || error}
+              </Alert>
+            )}
+
+            <form onSubmit={handleSubmit}>
+              <TextField
+                fullWidth
+                label="CoN Username"
+                name="conUsername"
+                value={formData.conUsername}
+                onChange={handleChange}
+                margin="normal"
+                required
+                autoComplete="username"
+                autoFocus
+              />
+
+              <TextField
+                fullWidth
+                label="Dashboard Password"
+                name="password"
+                type="password"
+                value={formData.password}
+                onChange={handleChange}
+                margin="normal"
+                required
+                autoComplete="current-password"
+              />
+
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                size="large"
+                disabled={loading}
+                sx={{ mt: 3, mb: 2 }}
+              >
+                {loading ? <CircularProgress size={24} /> : 'Sign In'}
+              </Button>
+            </form>
+
+            <Box textAlign="center">
+              <Typography variant="body2" color="textSecondary">
+                Don't have an account?{' '}
+                <Link component={RouterLink} to="/register">
+                  Register here
+                </Link>
+              </Typography>
+            </Box>
+          </CardContent>
+        </Card>
+      </Box>
+    </Container>
+  );
+};
+
+export default LoginPage;

--- a/Clients/alliance/frontend/src/pages/RegisterPage.js
+++ b/Clients/alliance/frontend/src/pages/RegisterPage.js
@@ -1,0 +1,201 @@
+import React, { useState } from 'react';
+import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import {
+  Box,
+  Card,
+  CardContent,
+  TextField,
+  Button,
+  Typography,
+  Alert,
+  Link,
+  CircularProgress,
+  Container,
+  Divider,
+} from '@mui/material';
+import { useAuth } from '../context/AuthContext';
+
+const RegisterPage = () => {
+  const navigate = useNavigate();
+  const { register, error } = useAuth();
+  const [formData, setFormData] = useState({
+    conUsername: '',
+    conPassword: '',
+    dashboardPassword: '',
+    confirmPassword: '',
+    email: '',
+  });
+  const [loading, setLoading] = useState(false);
+  const [localError, setLocalError] = useState('');
+
+  const handleChange = (e) => {
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLocalError('');
+
+    // Validate passwords match
+    if (formData.dashboardPassword !== formData.confirmPassword) {
+      setLocalError('Dashboard passwords do not match');
+      return;
+    }
+
+    if (formData.dashboardPassword.length < 8) {
+      setLocalError('Dashboard password must be at least 8 characters');
+      return;
+    }
+
+    setLoading(true);
+
+    const result = await register(
+      formData.conUsername,
+      formData.conPassword,
+      formData.dashboardPassword,
+      formData.email
+    );
+    setLoading(false);
+
+    if (result.success) {
+      navigate('/dashboard');
+    } else {
+      setLocalError(result.error);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        minHeight="100vh"
+        py={4}
+      >
+        <Typography variant="h3" component="h1" gutterBottom color="primary">
+          Conlyse
+        </Typography>
+        <Typography variant="h6" color="textSecondary" gutterBottom>
+          Alliance Dashboard
+        </Typography>
+
+        <Card sx={{ width: '100%', mt: 4 }}>
+          <CardContent sx={{ p: 4 }}>
+            <Typography variant="h5" component="h2" gutterBottom align="center">
+              Create Account
+            </Typography>
+
+            {(localError || error) && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {localError || error}
+              </Alert>
+            )}
+
+            <Alert severity="info" sx={{ mb: 2 }}>
+              Your Conflict of Nations credentials are used to verify your identity.
+              They are not stored - only your CoN username is saved.
+            </Alert>
+
+            <form onSubmit={handleSubmit}>
+              <Typography variant="subtitle2" color="textSecondary" sx={{ mt: 2, mb: 1 }}>
+                Conflict of Nations Account
+              </Typography>
+
+              <TextField
+                fullWidth
+                label="CoN Username"
+                name="conUsername"
+                value={formData.conUsername}
+                onChange={handleChange}
+                margin="normal"
+                required
+                autoComplete="username"
+                autoFocus
+                helperText="Your Conflict of Nations username"
+              />
+
+              <TextField
+                fullWidth
+                label="CoN Password"
+                name="conPassword"
+                type="password"
+                value={formData.conPassword}
+                onChange={handleChange}
+                margin="normal"
+                required
+                helperText="Used only for verification - not stored"
+              />
+
+              <Divider sx={{ my: 3 }} />
+
+              <Typography variant="subtitle2" color="textSecondary" sx={{ mb: 1 }}>
+                Dashboard Account
+              </Typography>
+
+              <TextField
+                fullWidth
+                label="Dashboard Password"
+                name="dashboardPassword"
+                type="password"
+                value={formData.dashboardPassword}
+                onChange={handleChange}
+                margin="normal"
+                required
+                helperText="Create a separate password for this dashboard (min 8 characters)"
+              />
+
+              <TextField
+                fullWidth
+                label="Confirm Dashboard Password"
+                name="confirmPassword"
+                type="password"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+                margin="normal"
+                required
+              />
+
+              <TextField
+                fullWidth
+                label="Email (optional)"
+                name="email"
+                type="email"
+                value={formData.email}
+                onChange={handleChange}
+                margin="normal"
+                helperText="For account recovery"
+              />
+
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                size="large"
+                disabled={loading}
+                sx={{ mt: 3, mb: 2 }}
+              >
+                {loading ? <CircularProgress size={24} /> : 'Create Account'}
+              </Button>
+            </form>
+
+            <Box textAlign="center">
+              <Typography variant="body2" color="textSecondary">
+                Already have an account?{' '}
+                <Link component={RouterLink} to="/login">
+                  Sign in
+                </Link>
+              </Typography>
+            </Box>
+          </CardContent>
+        </Card>
+      </Box>
+    </Container>
+  );
+};
+
+export default RegisterPage;


### PR DESCRIPTION
New client that allows alliance members to have their own personalized dashboards with CoN credential verification:

Backend (Flask):
- User authentication with CoN credential verification
- JWT-based session management with secure password hashing
- Alliance CRUD with invite code system
- Personal dashboard API (my games, my stats)
- Alliance dashboard API (shared games, members)

Frontend (React):
- Login/Register with CoN verification
- Personal dashboard with game stats
- Alliance management (create, join, leave)
- Alliance detail view with member list and shared games
- Dark theme Material-UI design
- Protected routes with auth context

Docker:
- Multi-stage builds for optimized images
- docker-compose for fresh installation (includes MySQL)
- docker-compose.external-db for existing database connection
- nginx reverse proxy with API proxying
- Ready for Cloudflare deployment