### PR TITLE
Add bulk game limit option for recording conversion

### DIFF
--- a/apps/desktop/src/conlyse/pages/map_page/map.py
+++ b/apps/desktop/src/conlyse/pages/map_page/map.py
@@ -211,7 +211,7 @@ class Map(QOpenGLWidget):
 
     def _initialize_world_labels(self):
         for province in self.ritf.get_provinces().values():
-            if isinstance(province, SeaProvince):
+            if province.C == "ultshared.UltSeaProvince":
                 continue
             if province.province_state_id not in (
                 ProvinceStateID.MAINLAND_CITY,

--- a/apps/desktop/src/conlyse/pages/map_page/map_views/political_view.py
+++ b/apps/desktop/src/conlyse/pages/map_page/map_views/political_view.py
@@ -50,7 +50,7 @@ class PoliticalView(MapView):
         owner_color_data = {}
 
         for province in self.ritf.get_provinces().values():
-            if isinstance(province, SeaProvince):
+            if province.C == "ultshared.UltSeaProvince":
                 self.color_data[province.id] = (70, 130, 180, 255)
                 continue
 

--- a/apps/desktop/src/conlyse/pages/map_page/map_views/resource_view.py
+++ b/apps/desktop/src/conlyse/pages/map_page/map_views/resource_view.py
@@ -46,11 +46,11 @@ class ResourceView(MapView):
         self.provinces_by_resource.clear()
 
         for province in self.ritf.get_provinces().values():
-            if isinstance(province, SeaProvince):
+            if province.C == "ultshared.UltSeaProvince":
                 continue
 
             rt = province.resource_production_type
-            if rt == ResourceProductionType.NONE:
+            if rt.value == ResourceProductionType.NONE.value:
                 continue
 
             prod = province.resource_production
@@ -68,7 +68,7 @@ class ResourceView(MapView):
 
     def _build_color_data(self):
         for province in self.ritf.get_provinces().values():
-            if isinstance(province, SeaProvince):
+            if province.C == "ultshared.UltSeaProvince":
                 self.color_data[province.id] = (70, 130, 180, 255)
                 continue
 

--- a/apps/desktop/src/conlyse/widgets/dock_system/docks/province_info_dock.py
+++ b/apps/desktop/src/conlyse/widgets/dock_system/docks/province_info_dock.py
@@ -164,7 +164,7 @@ class ProvinceInfoDock(Dock):
             self._show_no_province()
             return
 
-        if isinstance(province, SeaProvince):
+        if province.C == "ultshared.UltSeaProvince":
             self._show_sea_province(province)
         else:
             self._show_land_province(province)

--- a/libs/conflict_interface/conflict_interface/interface/game_interface.py
+++ b/libs/conflict_interface/conflict_interface/interface/game_interface.py
@@ -147,7 +147,7 @@ class GameInterface:
     def get_land_provinces(self, **filters) -> dict[int, LandProvince]:
         res = {}
         for province in self.game_state.states.map_state.map.provinces.values():
-            if isinstance(province, SeaProvince):
+            if province.C == "ultshared.UltSeaProvince":
                 continue
             if all([hasattr(province, key) and getattr(province, key) == val
                     for key, val in filters.items()]):

--- a/tools/recording_converter/README.md
+++ b/tools/recording_converter/README.md
@@ -225,6 +225,7 @@ recording-converter \
   --output-dir /data/replays \
   --mode gmr \
   --bulk \
+  --bulk-game-limit 100 \
   -p 8 \
   --game-id 12345 \
   --player-id 67890 \
@@ -235,6 +236,7 @@ Behavior:
 
 - Each subdirectory `/data/recordings_root/<name>` that contains `game_states.bin` becomes a job.
 - For each job, a replay file `/data/replays/<name>.bin` is created.
+- You can cap how many jobs run via `--bulk-game-limit N` (applied after optional name filtering).
 - Existing output files are overwritten only if `--overwrite` is provided.
 
 #### Example: bulk `rur` conversion with filters

--- a/tools/recording_converter/src/recording_converter/__main__.py
+++ b/tools/recording_converter/src/recording_converter/__main__.py
@@ -102,6 +102,13 @@ Patch creation modes:
     )
 
     parser.add_argument(
+        '--bulk-game-limit',
+        type=int,
+        default=None,
+        help='In bulk mode: limit number of recordings/games to convert after filtering'
+    )
+
+    parser.add_argument(
         '-p', '--processes',
         type=int,
         default=os.cpu_count() or 1,
@@ -197,6 +204,7 @@ Patch creation modes:
                 player_id=args.player_id,
                 use_tqdm=not args.no_progress,
                 recording_name_filters=args.recording_names,
+                max_games=args.bulk_game_limit,
             )
         except Exception:
             sys.exit(1)

--- a/tools/recording_converter/src/recording_converter/converter.py
+++ b/tools/recording_converter/src/recording_converter/converter.py
@@ -150,6 +150,7 @@ def convert_recordings_root(
     player_id: Optional[int] = None,
     use_tqdm: bool = True,
     recording_name_filters: Optional[Sequence[str]] = None,
+    max_games: Optional[int] = None,
 ) -> bool:
     """
     Convert all recording subdirectories under a root directory into replay files.
@@ -173,6 +174,13 @@ def convert_recordings_root(
     if recording_name_filters:
         allowed_names = set(recording_name_filters)
         recording_dirs = [d for d in recording_dirs if d.name in allowed_names]
+
+    # Optionally cap total number of recordings/games processed in bulk mode.
+    if max_games is not None:
+        if max_games < 1:
+            logger.error("Invalid bulk game limit %s; expected a positive integer", max_games)
+            return False
+        recording_dirs = recording_dirs[:max_games]
 
     if not recording_dirs:
         logger.warning("No recording subdirectories found under %s", root)


### PR DESCRIPTION
This pull request introduces two main groups of changes: (1) updates to how sea provinces are identified throughout the codebase, replacing `isinstance` checks with a string comparison on a class attribute, and (2) enhancements to the `recording_converter` tool, adding support for limiting the number of games processed in bulk mode via a new command-line argument. These changes improve both code clarity and user control over bulk operations.

**Sea province identification refactor:**

* Replaced all `isinstance(province, SeaProvince)` checks with `province.C == "ultshared.UltSeaProvince"` in multiple files (`map.py`, `political_view.py`, `resource_view.py`, `province_info_dock.py`, and `game_interface.py`) to standardize and possibly decouple province type identification logic. [[1]](diffhunk://#diff-ebff6795a0fdd191610aa7d90697546660bff4e75ffc7b50e1138d7269bd9684L214-R214) [[2]](diffhunk://#diff-3c72a05246c6685048cb020b342311efe34a4bc48ae0626bc8f2f0070b77deeeL53-R53) [[3]](diffhunk://#diff-47522a0aaf4a69a97b4cc7d624d42a609c4d19d8c57b9e604146530ce97d0e4dL49-R53) [[4]](diffhunk://#diff-47522a0aaf4a69a97b4cc7d624d42a609c4d19d8c57b9e604146530ce97d0e4dL71-R71) [[5]](diffhunk://#diff-b6110c21743c7d9c91408c90f4028ec0ef011608abcf38d4a4720964481681eeL167-R167) [[6]](diffhunk://#diff-3036dc3fe884ec393b5b0f00fe4258328865c579883ee2c619e8f4f255aa69c5L150-R150)

**Bulk game limit feature for recording converter:**

* Added a `--bulk-game-limit` argument to the recording converter CLI, allowing users to cap the number of recordings/games processed in bulk mode.
* Updated the CLI help and README documentation to describe the new `--bulk-game-limit` feature and its usage. [[1]](diffhunk://#diff-be6385dc493b4144983bca82a25614024804cf731357a4ff6998d66c73fba0c6R228) [[2]](diffhunk://#diff-be6385dc493b4144983bca82a25614024804cf731357a4ff6998d66c73fba0c6R239)
* Modified the main entry point and `convert_recordings_root` function to accept and enforce the `max_games` parameter, including error handling for invalid values. [[1]](diffhunk://#diff-cd38b1c6d8e370519cd61557c3f8868b2938d8b6652eafc9b042707ec1716c0dR207) [[2]](diffhunk://#diff-318280955af1e74e767c59db8d353c89bfe78ab0df16f6eed41b757c4e98966bR153) [[3]](diffhunk://#diff-318280955af1e74e767c59db8d353c89bfe78ab0df16f6eed41b757c4e98966bR178-R184)