### PR TITLE
Fix nuitka build process

### DIFF
--- a/apps/desktop/build_nuitka.py
+++ b/apps/desktop/build_nuitka.py
@@ -40,10 +40,14 @@ def main() -> None:
         f"--enable-plugin={ui_plugin}",
         "--follow-imports",
         f"--output-dir={output_dir}",
-        "--msvc=latest",
         "--assume-yes-for-downloads",
         str(entrypoint),
     ]
+
+    if sys.platform == "win32":
+        command.insert(-1, "--msvc=latest")
+    elif sys.platform == "darwin":
+        command.insert(-1, "--clang")
 
     if assets_dir.exists():
         command.append(f"--include-data-dir={assets_dir}=assets")


### PR DESCRIPTION
This pull request updates the build script for Nuitka to improve cross-platform compatibility when building the desktop app. The main change is to ensure the correct compiler flag is used depending on the operating system.

Build process improvements:

* The script now adds the `--msvc=latest` flag only when running on Windows (`win32`), and adds the `--clang` flag when running on macOS (`darwin`), ensuring the appropriate compiler is used for each platform. (`apps/desktop/build_nuitka.py`, [apps/desktop/build_nuitka.pyL43-R51](diffhunk://#diff-5eca503b45a4c57f5666162c2b89db92ea87579bd6a1710a4a6edf42664eef5cL43-R51))