### PR TITLE
Statistics

### DIFF
--- a/apps/docs/src/components/statistics/charts/CountryDiplomacyChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryDiplomacyChart.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { CountryAggregate } from '../types';
+
+interface Props {
+  data: CountryAggregate[];
+  topN?: number;
+  minGames?: number;
+}
+
+export default function CountryDiplomacyChart({ data, topN = 20, minGames = 3 }: Props) {
+  const chartData = [...data]
+    .filter((c) => c.games_played >= minGames)
+    .sort((a, b) => b.avg_wars_declared - a.avg_wars_declared)
+    .slice(0, topN)
+    .map((c) => ({
+      name: c.nation_name,
+      wars: parseFloat(c.avg_wars_declared.toFixed(1)),
+      peace: parseFloat(c.avg_peace_treaties_signed.toFixed(1)),
+      alliances: parseFloat(c.avg_alliances_formed.toFixed(1)),
+      rows: parseFloat(c.avg_right_of_ways_signed.toFixed(1)),
+      games: c.games_played,
+    }));
+
+  return (
+    <ResponsiveContainer width="100%" height={Math.max(300, chartData.length * 26)}>
+      <BarChart
+        data={chartData}
+        layout="vertical"
+        margin={{ top: 8, right: 48, left: 4, bottom: 8 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--ifm-color-emphasis-300)" horizontal={false} />
+        <XAxis
+          type="number"
+          tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }}
+          allowDecimals={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="name"
+          tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }}
+          width={95}
+        />
+        <Tooltip
+          contentStyle={{
+            background: 'var(--ifm-background-surface-color)',
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: 6,
+            color: 'var(--ifm-font-color-base)',
+          }}
+          formatter={(value: number, _: string, props) => {
+            const { peace, alliances, rows, games } = props.payload;
+            return [
+              `${value} wars · ${peace} peace · ${alliances} alliances · ${rows} ROW · ${games} games`,
+              'Avg wars declared',
+            ];
+          }}
+        />
+        <Bar dataKey="wars" radius={[0, 3, 3, 0]}>
+          {chartData.map((entry, index) => (
+            <Cell
+              key={`cell-${index}`}
+              fill={entry.wars >= 5 ? '#e74c3c' : entry.wars >= 2 ? '#f5a623' : '#4a90e2'}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/docs/src/components/statistics/charts/CountryProvincesTimeSeriesChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryProvincesTimeSeriesChart.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { CountryAggregate, TimeSeriesOutput } from '../types';
+
+interface Props {
+  data: TimeSeriesOutput;
+  countries: CountryAggregate[];
+  topN?: number;
+}
+
+type Mode = 'pct' | 'days';
+
+const COLORS = [
+  '#4a90e2', '#50c878', '#f5a623', '#e74c3c', '#9b59b6',
+  '#1abc9c', '#e67e22', '#3498db', '#c0392b', '#2ecc71',
+];
+
+export default function CountryProvincesTimeSeriesChart({ data, countries, topN = 10 }: Props) {
+  const [mode, setMode] = useState<Mode>('pct');
+
+  const topCountries = [...countries]
+    .sort((a, b) => b.games_played - a.games_played)
+    .slice(0, topN)
+    .map((c) => c.nation_name);
+
+  const seriesData = data.countries.filter((c) => topCountries.includes(c.nation_name));
+
+  const buckets = mode === 'pct'
+    ? data.pct_buckets
+    : Array.from({ length: data.max_game_days + 1 }, (_, i) => i);
+
+  const chartData = buckets.map((b) => {
+    const row: Record<string, number | string> = { bucket: b };
+    for (const c of seriesData) {
+      const series = mode === 'pct' ? c.pct_game : c.game_days;
+      const pt = series.find((p) => p.bucket === b);
+      if (pt !== undefined) {
+        row[c.nation_name] = pt.avg_provinces;
+      }
+    }
+    return row;
+  });
+
+  return (
+    <div>
+      <div style={{ marginBottom: 12, display: 'flex', gap: 8 }}>
+        <button
+          onClick={() => setMode('pct')}
+          style={{
+            padding: '4px 14px',
+            borderRadius: 4,
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            background: mode === 'pct' ? 'var(--ifm-color-primary)' : 'transparent',
+            color: mode === 'pct' ? '#fff' : 'var(--ifm-font-color-base)',
+            cursor: 'pointer',
+            fontSize: 12,
+          }}
+        >
+          % of Game
+        </button>
+        <button
+          onClick={() => setMode('days')}
+          style={{
+            padding: '4px 14px',
+            borderRadius: 4,
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            background: mode === 'days' ? 'var(--ifm-color-primary)' : 'transparent',
+            color: mode === 'days' ? '#fff' : 'var(--ifm-font-color-base)',
+            cursor: 'pointer',
+            fontSize: 12,
+          }}
+        >
+          Game Days
+        </button>
+      </div>
+
+      <ResponsiveContainer width="100%" height={420}>
+        <LineChart data={chartData} margin={{ top: 8, right: 16, left: 4, bottom: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--ifm-color-emphasis-300)" />
+          <XAxis
+            dataKey="bucket"
+            tickFormatter={(v) => mode === 'pct' ? `${v}%` : `Day ${v}`}
+            tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }}
+            interval={mode === 'pct' ? 3 : Math.floor(data.max_game_days / 10)}
+          />
+          <YAxis
+            tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }}
+            label={{
+              value: 'Avg Provinces',
+              angle: -90,
+              position: 'insideLeft',
+              offset: 12,
+              style: { fontSize: 11, fill: 'var(--ifm-font-color-base)' },
+            }}
+          />
+          <Tooltip
+            contentStyle={{
+              background: 'var(--ifm-background-surface-color)',
+              border: '1px solid var(--ifm-color-emphasis-300)',
+              borderRadius: 6,
+              color: 'var(--ifm-font-color-base)',
+            }}
+            formatter={(value: number, name: string) => [`${value} avg provinces`, name]}
+            labelFormatter={(label) => mode === 'pct' ? `${label}% of game` : `Day ${label}`}
+          />
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+          {seriesData.map((c, i) => (
+            <Line
+              key={c.nation_name}
+              type="monotone"
+              dataKey={c.nation_name}
+              stroke={COLORS[i % COLORS.length]}
+              dot={false}
+              strokeWidth={2}
+              connectNulls
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/apps/docs/src/components/statistics/charts/CountryRadarChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryRadarChart.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import {
+  Legend,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+import type { CountryAggregate } from '../types';
+
+interface Props {
+  data: CountryAggregate[];
+  topN?: number;
+}
+
+const COLORS = [
+  '#4a90e2', '#50c878', '#f5a623', '#e74c3c', '#9b59b6', '#1abc9c',
+];
+
+const DIMENSIONS = [
+  { key: 'win_rate',              label: 'Win Rate',      raw: (c: CountryAggregate) => c.win_rate },
+  { key: 'avg_expansion',        label: 'Expansion',     raw: (c: CountryAggregate) => c.avg_expansion },
+  { key: 'avg_prov_captured',    label: 'Aggression',    raw: (c: CountryAggregate) => c.avg_provinces_captured },
+  { key: 'survival',             label: 'Survival',      raw: (c: CountryAggregate) => 1 - c.elimination_rate },
+  { key: 'avg_final_provinces',  label: 'Territory',     raw: (c: CountryAggregate) => c.avg_final_provinces },
+];
+
+function normalize(values: number[]): number[] {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  if (max === min) return values.map(() => 50);
+  return values.map((v) => parseFloat(((v - min) / (max - min) * 100).toFixed(1)));
+}
+
+interface TooltipPayload {
+  name: string;
+  value: number;
+  payload: Record<string, number | string>;
+}
+
+function CustomTooltip({ active, payload, label }: { active?: boolean; payload?: TooltipPayload[]; label?: string }) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div style={{
+      background: 'var(--ifm-background-surface-color)',
+      border: '1px solid var(--ifm-color-emphasis-300)',
+      borderRadius: 6,
+      padding: '8px 12px',
+      fontSize: 12,
+      color: 'var(--ifm-font-color-base)',
+      lineHeight: 1.6,
+    }}>
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>{label}</div>
+      {payload.map((p) => (
+        <div key={p.name} style={{ color: 'var(--ifm-font-color-base)' }}>
+          {p.name}: <strong>{p.value.toFixed(1)}</strong> (normalized)
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function CountryRadarChart({ data, topN = 6 }: Props) {
+  const top = [...data].sort((a, b) => b.games_played - a.games_played).slice(0, topN);
+
+  const rawByDim = DIMENSIONS.map((dim) => top.map((c) => dim.raw(c)));
+  const normalizedByDim = rawByDim.map(normalize);
+
+  const chartData = DIMENSIONS.map((dim, di) => {
+    const row: Record<string, number | string> = { dimension: dim.label };
+    top.forEach((c, ci) => {
+      row[c.nation_name] = normalizedByDim[di][ci];
+    });
+    return row;
+  });
+
+  return (
+    <ResponsiveContainer width="100%" height={380}>
+      <RadarChart data={chartData} margin={{ top: 16, right: 32, left: 32, bottom: 16 }}>
+        <PolarGrid stroke="var(--ifm-color-emphasis-300)" />
+        <PolarAngleAxis
+          dataKey="dimension"
+          tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }}
+        />
+        <PolarRadiusAxis
+          angle={90}
+          domain={[0, 100]}
+          tick={{ fontSize: 9, fill: 'var(--ifm-color-emphasis-400)' }}
+          tickCount={4}
+        />
+        <Tooltip content={<CustomTooltip />} />
+        <Legend wrapperStyle={{ fontSize: 11 }} />
+        {top.map((c, i) => (
+          <Radar
+            key={c.nation_name}
+            name={c.nation_name}
+            dataKey={c.nation_name}
+            stroke={COLORS[i % COLORS.length]}
+            fill={COLORS[i % COLORS.length]}
+            fillOpacity={0.12}
+            strokeWidth={2}
+          />
+        ))}
+      </RadarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/docs/src/components/statistics/charts/DiplomacyGlobalChart.tsx
+++ b/apps/docs/src/components/statistics/charts/DiplomacyGlobalChart.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { GlobalAggregate } from '../types';
+
+interface Props {
+  data: GlobalAggregate;
+}
+
+const METRICS = [
+  { key: 'avg_wars_per_game',          label: 'Wars Declared',   color: '#e74c3c' },
+  { key: 'avg_right_of_ways_per_game', label: 'Right of Ways',   color: '#4a90e2' },
+  { key: 'avg_peace_treaties_per_game',label: 'Peace Treaties',  color: '#50c878' },
+  { key: 'avg_alliances_per_game',     label: 'Alliances',       color: '#9b59b6' },
+] as const;
+
+export default function DiplomacyGlobalChart({ data }: Props) {
+  const chartData = METRICS.map((m) => ({
+    name: m.label,
+    value: parseFloat((data[m.key] as number).toFixed(1)),
+    color: m.color,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={180}>
+      <BarChart
+        data={chartData}
+        layout="vertical"
+        margin={{ top: 4, right: 48, left: 4, bottom: 4 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--ifm-color-emphasis-300)" horizontal={false} />
+        <XAxis
+          type="number"
+          tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }}
+          allowDecimals={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="name"
+          tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }}
+          width={110}
+        />
+        <Tooltip
+          contentStyle={{
+            background: 'var(--ifm-background-surface-color)',
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: 6,
+            color: 'var(--ifm-font-color-base)',
+          }}
+          formatter={(value: number, _: string) => [`${value} per game`, 'Avg']}
+        />
+        <Bar dataKey="value" radius={[0, 3, 3, 0]}>
+          {chartData.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={entry.color} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/docs/src/components/statistics/charts/GameDurationChart.tsx
+++ b/apps/docs/src/components/statistics/charts/GameDurationChart.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export default function GameDurationChart({ data }: Props) {
   const chartData = data.map((b) => ({
-    label: `${b.min_hours.toFixed(0)}–${b.max_hours.toFixed(0)}h`,
+    label: `${b.min_days.toFixed(0)}–${b.max_days.toFixed(0)}d`,
     count: b.count,
   }));
 

--- a/apps/docs/src/components/statistics/charts/ProvinceStrategicScatterChart.tsx
+++ b/apps/docs/src/components/statistics/charts/ProvinceStrategicScatterChart.tsx
@@ -1,0 +1,151 @@
+import React, { useMemo } from 'react';
+import {
+  CartesianGrid,
+  Label,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { ProvinceAggregate } from '../types';
+
+interface Props {
+  data: ProvinceAggregate[];
+}
+
+const TERRAIN_COLOURS: Record<string, string> = {
+  PLAINS:   '#7bc67a',
+  HILLS:    '#b8a05a',
+  MOUNTAIN: '#8c9db5',
+  FOREST:   '#3a8a4a',
+  URBAN:    '#5b7ec9',
+  JUNGLE:   '#2e7d52',
+  TUNDRA:   '#8ecae6',
+  DESERT:   '#e9c46a',
+  SUBURBAN: '#9b72cf',
+};
+
+const QUADRANT_STYLE = {
+  fontSize: 10,
+  fill: 'var(--ifm-color-emphasis-400)',
+  fontStyle: 'italic' as const,
+};
+
+interface ScatterPoint {
+  name: string;
+  terrain: string;
+  contest: number;
+  winCorr: number;
+  fill: string;
+}
+
+const OUTLIER_N = 8;
+
+function buildOutlierSet(points: ScatterPoint[]): Set<string> {
+  const top = (sorted: ScatterPoint[]) => sorted.slice(0, OUTLIER_N).map((p) => p.name);
+  return new Set([
+    ...top([...points].sort((a, b) => b.contest - a.contest)),
+    ...top([...points].sort((a, b) => b.winCorr - a.winCorr)),
+    ...top([...points].sort((a, b) => (b.contest + b.winCorr) - (a.contest + a.winCorr))),
+  ]);
+}
+
+function makeDotRenderer(outliers: Set<string>) {
+  return function CustomDot(props: { cx?: number; cy?: number; payload?: ScatterPoint }) {
+    const { cx = 0, cy = 0, payload } = props;
+    if (!payload) return null;
+    const isOutlier = outliers.has(payload.name);
+    const lx = payload.contest > 55 ? cx - 6 : cx + 6;
+    const ly = payload.winCorr > 55 ? cy + 11 : cy - 5;
+    return (
+      <g>
+        <circle
+          cx={cx}
+          cy={cy}
+          r={isOutlier ? 4 : 2}
+          fill={payload.fill}
+          fillOpacity={isOutlier ? 0.9 : 0.4}
+        />
+        {isOutlier && (
+          <text
+            x={lx}
+            y={ly}
+            fontSize={9}
+            fill="var(--ifm-font-color-base)"
+            textAnchor={payload.contest > 55 ? 'end' : 'start'}
+          >
+            {payload.name}
+          </text>
+        )}
+      </g>
+    );
+  };
+}
+
+function TerrainLegend({ terrains }: { terrains: string[] }) {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 14px', marginTop: 10, fontSize: 11, color: 'var(--ifm-font-color-base)' }}>
+      {terrains.map((t) => (
+        <span key={t} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <span style={{ width: 8, height: 8, borderRadius: '50%', background: TERRAIN_COLOURS[t] ?? '#aaa', display: 'inline-block' }} />
+          {t.charAt(0) + t.slice(1).toLowerCase()}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function ProvinceStrategicScatterChart({ data }: Props) {
+  const points = useMemo<ScatterPoint[]>(
+    () => data.map((p) => ({
+      name: p.province_name,
+      terrain: p.terrain_type,
+      contest: p.contest_frequency * 100,
+      winCorr: p.win_correlation * 100,
+      fill: TERRAIN_COLOURS[p.terrain_type] ?? '#aaaaaa',
+    })),
+    [data],
+  );
+
+  const outlierSet = useMemo(() => buildOutlierSet(points), [points]);
+  const terrains = useMemo(() => [...new Set(points.map((p) => p.terrain))].sort(), [points]);
+  const CustomDot = useMemo(() => makeDotRenderer(outlierSet), [outlierSet]);
+
+  return (
+    <div>
+      <ResponsiveContainer width="100%" height={480}>
+        <ScatterChart margin={{ top: 24, right: 24, left: 8, bottom: 24 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--ifm-color-emphasis-200)" />
+          <XAxis
+            type="number"
+            dataKey="contest"
+            domain={[0, 100]}
+            tickFormatter={(v) => `${v}%`}
+            tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }}
+            label={{ value: 'Contest frequency →', position: 'insideBottom', offset: -14, fontSize: 11, fill: 'var(--ifm-color-emphasis-500)' }}
+          />
+          <YAxis
+            type="number"
+            dataKey="winCorr"
+            domain={[0, 100]}
+            tickFormatter={(v) => `${v}%`}
+            tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }}
+            label={{ value: '← Win correlation', angle: -90, position: 'insideLeft', offset: 14, fontSize: 11, fill: 'var(--ifm-color-emphasis-500)' }}
+          />
+          <ReferenceLine x={50} stroke="var(--ifm-color-emphasis-300)" strokeDasharray="4 4">
+            <Label value="Strategic Hotspots" position="insideTopRight" style={QUADRANT_STYLE} />
+            <Label value="Battlegrounds" position="insideBottomRight" style={QUADRANT_STYLE} />
+          </ReferenceLine>
+          <ReferenceLine y={50} stroke="var(--ifm-color-emphasis-300)" strokeDasharray="4 4">
+            <Label value="Key Objectives" position="insideTopLeft" style={QUADRANT_STYLE} />
+            <Label value="Peripheral" position="insideBottomLeft" style={QUADRANT_STYLE} />
+          </ReferenceLine>
+          <Scatter data={points} shape={CustomDot} />
+        </ScatterChart>
+      </ResponsiveContainer>
+      <TerrainLegend terrains={terrains} />
+    </div>
+  );
+}

--- a/apps/docs/src/components/statistics/deserialize.ts
+++ b/apps/docs/src/components/statistics/deserialize.ts
@@ -1,0 +1,79 @@
+import type {
+  ColumnarData,
+  CountryAggregate,
+  CountryTimeSeries,
+  ProvinceAggregate,
+  TimeSeriesOutput,
+} from './types';
+
+export function deserializeCountries(raw: ColumnarData): CountryAggregate[] {
+  const idx = Object.fromEntries(raw.columns.map((c, i) => [c, i]));
+  return raw.rows.map((r) => ({
+    nation_name:           r[idx.nation_name]           as string,
+    games_played:          r[idx.games_played]          as number,
+    wins:                  r[idx.wins]                  as number,
+    win_rate:              r[idx.win_rate]              as number,
+    avg_final_vp:          r[idx.avg_final_vp]          as number,
+    avg_placement:         r[idx.avg_placement]         as number,
+    median_placement:      r[idx.median_placement]      as number,
+    avg_final_provinces:   r[idx.avg_final_provinces]   as number,
+    avg_initial_provinces: r[idx.avg_initial_provinces] as number,
+    avg_expansion:         r[idx.avg_expansion]         as number,
+    avg_provinces_captured:r[idx.avg_provinces_captured]as number,
+    avg_provinces_lost:    r[idx.avg_provinces_lost]    as number,
+    elimination_rate:      r[idx.elimination_rate]      as number,
+    avg_survival_days:     r[idx.avg_survival_days]     as number,
+  }));
+}
+
+export function deserializeProvinces(raw: ColumnarData): ProvinceAggregate[] {
+  const idx = Object.fromEntries(raw.columns.map((c, i) => [c, i]));
+  return raw.rows.map((r) => ({
+    province_id:              r[idx.province_id]              as number,
+    province_name:            r[idx.province_name]            as string,
+    terrain_type:             r[idx.terrain_type]             as string,
+    is_coastal:               r[idx.is_coastal]               as boolean,
+    games_appeared:           r[idx.games_appeared]           as number,
+    avg_ownership_changes:    r[idx.avg_ownership_changes]    as number,
+    contest_frequency:        r[idx.contest_frequency]        as number,
+    win_correlation:          r[idx.win_correlation]          as number,
+    resource_production_type: r[idx.resource_production_type] as string | null,
+    avg_resource_production:  r[idx.avg_resource_production]  as number,
+    avg_money_production:     r[idx.avg_money_production]     as number,
+    avg_morale:               r[idx.avg_morale]               as number,
+  }));
+}
+
+export function deserializeTimeSeries(raw: {
+  pct_buckets: number[];
+  max_game_days: number;
+  generated_at: string;
+  countries: Array<{
+    nation_name: string;
+    games_played: number;
+    pct_avg: (number | null)[];
+    pct_n:   (number | null)[];
+    day_avg: (number | null)[];
+    day_n:   (number | null)[];
+  }>;
+}): TimeSeriesOutput {
+  return {
+    pct_buckets:  raw.pct_buckets,
+    max_game_days: raw.max_game_days,
+    generated_at:  raw.generated_at,
+    countries: raw.countries.map((c): CountryTimeSeries => ({
+      nation_name:  c.nation_name,
+      games_played: c.games_played,
+      pct_game: raw.pct_buckets
+        .map((b, i) => c.pct_avg[i] != null
+          ? { bucket: b, avg_provinces: c.pct_avg[i]!, games_sampled: c.pct_n[i]! }
+          : null)
+        .filter((p): p is NonNullable<typeof p> => p !== null),
+      game_days: c.day_avg
+        .map((v, i) => v != null
+          ? { bucket: i, avg_provinces: v, games_sampled: c.day_n[i]! }
+          : null)
+        .filter((p): p is NonNullable<typeof p> => p !== null),
+    })),
+  };
+}

--- a/apps/docs/src/components/statistics/deserialize.ts
+++ b/apps/docs/src/components/statistics/deserialize.ts
@@ -21,8 +21,12 @@ export function deserializeCountries(raw: ColumnarData): CountryAggregate[] {
     avg_expansion:         r[idx.avg_expansion]         as number,
     avg_provinces_captured:r[idx.avg_provinces_captured]as number,
     avg_provinces_lost:    r[idx.avg_provinces_lost]    as number,
-    elimination_rate:      r[idx.elimination_rate]      as number,
-    avg_survival_days:     r[idx.avg_survival_days]     as number,
+    elimination_rate:          r[idx.elimination_rate]          as number,
+    avg_survival_days:         r[idx.avg_survival_days]         as number,
+    avg_wars_declared:         r[idx.avg_wars_declared]         as number,
+    avg_peace_treaties_signed: r[idx.avg_peace_treaties_signed] as number,
+    avg_alliances_formed:      r[idx.avg_alliances_formed]      as number,
+    avg_right_of_ways_signed:  r[idx.avg_right_of_ways_signed]  as number,
   }));
 }
 

--- a/apps/docs/src/components/statistics/sections/CountryStatsSection.tsx
+++ b/apps/docs/src/components/statistics/sections/CountryStatsSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import CountryAggressivenessChart from '../charts/CountryAggressivenessChart';
+import CountryDiplomacyChart from '../charts/CountryDiplomacyChart';
 import CountryEliminationChart from '../charts/CountryEliminationChart';
 import CountryExpansionChart from '../charts/CountryExpansionChart';
 import CountryPlacementChart from '../charts/CountryPlacementChart';
@@ -53,6 +54,11 @@ export default function CountryStatsSection({ data }: Props) {
           <h3 className={styles.chartTitle}>Territory Aggressiveness (Top 20)</h3>
           <p className={styles.chartSubtitle}>Avg provinces captured per game · tooltip shows losses and net gain</p>
           <CountryAggressivenessChart data={data} topN={20} />
+        </div>
+        <div className={styles.chartCard}>
+          <h3 className={styles.chartTitle}>Wars Declared by Country (Top 20)</h3>
+          <p className={styles.chartSubtitle}>Avg wars declared per game · tooltip shows treaties and right-of-ways</p>
+          <CountryDiplomacyChart data={data} topN={20} />
         </div>
       </div>
     </section>

--- a/apps/docs/src/components/statistics/sections/GlobalStatsSection.tsx
+++ b/apps/docs/src/components/statistics/sections/GlobalStatsSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DiplomacyGlobalChart from '../charts/DiplomacyGlobalChart';
 import GameDurationChart from '../charts/GameDurationChart';
 import PlayerCountChart from '../charts/PlayerCountChart';
 import VictoryTypeChart from '../charts/VictoryTypeChart';
@@ -35,6 +36,13 @@ export default function GlobalStatsSection({ data }: Props) {
             Avg {data.avg_human_players_per_game.toFixed(1)} human players
           </p>
           <PlayerCountChart data={data.player_count_distribution} />
+        </div>
+        <div className={styles.chartCard}>
+          <h3 className={styles.chartTitle}>Diplomacy per Game</h3>
+          <p className={styles.chartSubtitle}>
+            Avg {data.avg_wars_per_game.toFixed(0)} wars · {data.avg_right_of_ways_per_game.toFixed(0)} right-of-ways · {data.avg_peace_treaties_per_game.toFixed(0)} peace treaties
+          </p>
+          <DiplomacyGlobalChart data={data} />
         </div>
       </div>
     </section>

--- a/apps/docs/src/components/statistics/sections/ProvinceStatsSection.tsx
+++ b/apps/docs/src/components/statistics/sections/ProvinceStatsSection.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import ProvinceContestedChart from '../charts/ProvinceContestedChart';
 import ProvinceMoraleChart from '../charts/ProvinceMoraleChart';
-import ProvinceWinCorrelationChart from '../charts/ProvinceWinCorrelationChart';
+import ProvinceStrategicScatterChart from '../charts/ProvinceStrategicScatterChart';
 import type { ProvinceAggregate } from '../types';
 import styles from './Section.module.css';
 
@@ -41,19 +40,10 @@ export default function ProvinceStatsSection({ data }: Props) {
         </div>
       </div>
       <div className={styles.grid}>
-        <div className={styles.chartCard}>
-          <h3 className={styles.chartTitle}>Most Contested Provinces (Top 25)</h3>
-          <p className={styles.chartSubtitle}>
-            % of games where ownership changed at least once
-          </p>
-          <ProvinceContestedChart data={filtered} topN={25} />
-        </div>
-        <div className={styles.chartCard}>
-          <h3 className={styles.chartTitle}>Win Correlation (Top 25)</h3>
-          <p className={styles.chartSubtitle}>
-            % of games where the winner controlled this province at game end
-          </p>
-          <ProvinceWinCorrelationChart data={filtered} topN={25} />
+        <div className={styles.chartCard} style={{ gridColumn: '1 / -1' }}>
+          <h3 className={styles.chartTitle}>Province Strategic Map</h3>
+          <p className={styles.chartSubtitle}>All provinces · contest frequency vs winner control rate · labeled outliers · coloured by terrain type</p>
+          <ProvinceStrategicScatterChart data={filtered} />
         </div>
         <div className={styles.chartCard}>
           <h3 className={styles.chartTitle}>Province Morale (Top 20)</h3>

--- a/apps/docs/src/components/statistics/sections/TimeSeriesSection.tsx
+++ b/apps/docs/src/components/statistics/sections/TimeSeriesSection.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import CountryProvincesTimeSeriesChart from '../charts/CountryProvincesTimeSeriesChart';
+import CountryRadarChart from '../charts/CountryRadarChart';
+import type { CountryAggregate, TimeSeriesOutput } from '../types';
+import styles from './Section.module.css';
+
+interface Props {
+  data: TimeSeriesOutput;
+  countries: CountryAggregate[];
+}
+
+export default function TimeSeriesSection({ data, countries }: Props) {
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <div>
+          <h2 className={styles.heading}>Province Control Over Time</h2>
+          <p className={styles.description}>
+            Average territory per country across {data.countries.length} nations · top 10 by games played · toggle between % of game and absolute game days
+          </p>
+        </div>
+      </div>
+      <div className={styles.grid}>
+        <div className={styles.chartCard} style={{ gridColumn: '1 / -1' }}>
+          <h3 className={styles.chartTitle}>Province Count Progression (Top 10 Nations)</h3>
+          <p className={styles.chartSubtitle}>Avg provinces held at each point in the game · use buttons to switch time axis</p>
+          <CountryProvincesTimeSeriesChart data={data} countries={countries} topN={10} />
+        </div>
+        <div className={styles.chartCard}>
+          <h3 className={styles.chartTitle}>Nation Profile Comparison (Top 6)</h3>
+          <p className={styles.chartSubtitle}>Normalized across all nations · win rate, expansion, aggression, survival, territory</p>
+          <CountryRadarChart data={countries} topN={6} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/docs/src/components/statistics/types.ts
+++ b/apps/docs/src/components/statistics/types.ts
@@ -25,6 +25,10 @@ export interface GlobalAggregate {
   avg_dropout_rate: number;
   avg_game_days: number;
   avg_update_interval_seconds: number;
+  avg_wars_per_game: number;
+  avg_peace_treaties_per_game: number;
+  avg_alliances_per_game: number;
+  avg_right_of_ways_per_game: number;
 }
 
 export interface CountryAggregate {
@@ -42,6 +46,10 @@ export interface CountryAggregate {
   avg_provinces_lost: number;
   elimination_rate: number;
   avg_survival_days: number;
+  avg_wars_declared: number;
+  avg_peace_treaties_signed: number;
+  avg_alliances_formed: number;
+  avg_right_of_ways_signed: number;
 }
 
 export interface ProvinceAggregate {

--- a/apps/docs/src/components/statistics/types.ts
+++ b/apps/docs/src/components/statistics/types.ts
@@ -1,8 +1,14 @@
 /** TypeScript interfaces mirroring the Python Pydantic aggregate models in game_stats_extractor. */
 
+/** Wire format for columnar JSON files (countries.json, provinces.json). */
+export interface ColumnarData {
+  columns: string[];
+  rows: unknown[][];
+}
+
 export interface DurationBucket {
-  min_hours: number;
-  max_hours: number;
+  min_days: number;
+  max_days: number;
   count: number;
 }
 
@@ -51,6 +57,26 @@ export interface ProvinceAggregate {
   avg_resource_production: number;
   avg_money_production: number;
   avg_morale: number;
+}
+
+export interface TimeSeriesPoint {
+  bucket: number;
+  avg_provinces: number;
+  games_sampled: number;
+}
+
+export interface CountryTimeSeries {
+  nation_name: string;
+  games_played: number;
+  pct_game: TimeSeriesPoint[];
+  game_days: TimeSeriesPoint[];
+}
+
+export interface TimeSeriesOutput {
+  countries: CountryTimeSeries[];
+  pct_buckets: number[];
+  max_game_days: number;
+  generated_at: string;
 }
 
 export interface MetaInfo {

--- a/apps/docs/src/pages/statistics/index.tsx
+++ b/apps/docs/src/pages/statistics/index.tsx
@@ -4,11 +4,18 @@ import StatsHero from '../../components/statistics/StatsHero';
 import CountryStatsSection from '../../components/statistics/sections/CountryStatsSection';
 import GlobalStatsSection from '../../components/statistics/sections/GlobalStatsSection';
 import ProvinceStatsSection from '../../components/statistics/sections/ProvinceStatsSection';
+import TimeSeriesSection from '../../components/statistics/sections/TimeSeriesSection';
+import {
+  deserializeCountries,
+  deserializeProvinces,
+  deserializeTimeSeries,
+} from '../../components/statistics/deserialize';
 import type {
   CountryAggregate,
   GlobalAggregate,
   MetaInfo,
   ProvinceAggregate,
+  TimeSeriesOutput,
 } from '../../components/statistics/types';
 import styles from './statistics.module.css';
 
@@ -17,18 +24,28 @@ interface StatsData {
   countries: CountryAggregate[];
   provinces: ProvinceAggregate[];
   meta: MetaInfo;
+  timeseries: TimeSeriesOutput;
 }
 
-const STATS_BASE_URL = 'https://r2.conlyse.zdox.dev/stats';
+const STATS_BASE_URL = process.env.NODE_ENV === 'development'
+  ? '/data/stats'
+  : 'https://r2.conlyse.zdox.dev/stats';
 
 async function fetchStats(): Promise<StatsData> {
-  const [global, countries, provinces, meta] = await Promise.all([
+  const [global, countriesRaw, provincesRaw, meta, timeseriesRaw] = await Promise.all([
     fetch(`${STATS_BASE_URL}/global.json`).then((r) => r.json()),
     fetch(`${STATS_BASE_URL}/countries.json`).then((r) => r.json()),
     fetch(`${STATS_BASE_URL}/provinces.json`).then((r) => r.json()),
     fetch(`${STATS_BASE_URL}/meta.json`).then((r) => r.json()),
+    fetch(`${STATS_BASE_URL}/timeseries.json`).then((r) => r.json()),
   ]);
-  return { global, countries, provinces, meta };
+  return {
+    global,
+    countries: deserializeCountries(countriesRaw),
+    provinces: deserializeProvinces(provincesRaw),
+    meta,
+    timeseries: deserializeTimeSeries(timeseriesRaw),
+  };
 }
 
 export default function StatisticsPage() {
@@ -70,6 +87,7 @@ export default function StatisticsPage() {
             <GlobalStatsSection data={data.global} />
             <CountryStatsSection data={data.countries} />
             <ProvinceStatsSection data={data.provinces} />
+            <TimeSeriesSection data={data.timeseries} countries={data.countries} />
           </>
         )}
       </main>

--- a/libs/conflict_interface/conflict_interface/hook_system/replay_hook_tag.py
+++ b/libs/conflict_interface/conflict_interface/hook_system/replay_hook_tag.py
@@ -9,3 +9,4 @@ class ReplayHookTag(Enum):
     ArmyChanged = auto()
     GameInfoChanged = auto()
     SegmentSwitch = auto()
+    ForeignAffairsRelationChanged = auto()

--- a/libs/conflict_interface/conflict_interface/interface/replay_interface.py
+++ b/libs/conflict_interface/conflict_interface/interface/replay_interface.py
@@ -596,3 +596,18 @@ class ReplayInterface(GameInterface):
 
         for hs in self._hook_systems.values():
             hs.unregister_event_trigger(path)
+
+    def register_foreign_affairs_trigger(self) -> None:
+        path = ["states", "foreign_affairs_state", "relations"]
+        for hs in self._hook_systems.values():
+            hs.register_event_trigger(
+                tag=ReplayHookTag.ForeignAffairsRelationChanged,
+                path=path,
+                attributes=["neighbor_relations"],
+                search_end_depth=0,
+            )
+
+    def unregister_foreign_affairs_trigger(self) -> None:
+        path = ["states", "foreign_affairs_state", "relations"]
+        for hs in self._hook_systems.values():
+            hs.unregister_event_trigger(path)

--- a/tools/game_stats_extractor/src/game_stats_extractor/__main__.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/__main__.py
@@ -56,6 +56,12 @@ Examples:
         default=3,
         help="Minimum number of game appearances for a province to be included in output (default: 3)",
     )
+    parser.add_argument(
+        "--min-timeseries-games",
+        type=int,
+        default=3,
+        help="Minimum number of games for a country to be included in time series output (default: 3)",
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable DEBUG logging")
     parser.add_argument("-q", "--quiet", action="store_true", help="Only show ERROR messages")
 
@@ -84,6 +90,7 @@ Examples:
         workers=args.workers,
         map_data_dir=args.map_data_dir,
         min_province_appearances=args.min_province_appearances,
+        min_timeseries_games=args.min_timeseries_games,
     )
 
     try:

--- a/tools/game_stats_extractor/src/game_stats_extractor/aggregators/country_aggregator.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/aggregators/country_aggregator.py
@@ -40,6 +40,10 @@ def _aggregate_country(
     eliminated = sum(1 for _, p in entries if p.is_defeated)
     captures = [p.provinces_captured for _, p in entries]
     losses = [p.provinces_lost for _, p in entries]
+    wars_declared = [p.wars_declared for _, p in entries]
+    peace_treaties = [p.peace_treaties_signed for _, p in entries]
+    alliances_formed = [p.alliances_formed for _, p in entries]
+    right_of_ways = [p.right_of_ways_signed for _, p in entries]
 
     # Placement: rank by final_vp within each game (1 = best)
     placements: list[float] = []
@@ -82,4 +86,8 @@ def _aggregate_country(
         avg_provinces_lost=_mean(losses),
         elimination_rate=eliminated / games_played,
         avg_survival_days=_mean(survival_days),
+        avg_wars_declared=_mean(wars_declared),
+        avg_peace_treaties_signed=_mean(peace_treaties),
+        avg_alliances_formed=_mean(alliances_formed),
+        avg_right_of_ways_signed=_mean(right_of_ways),
     )

--- a/tools/game_stats_extractor/src/game_stats_extractor/aggregators/global_aggregator.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/aggregators/global_aggregator.py
@@ -30,8 +30,6 @@ class GlobalAggregator(BaseAggregator[GlobalAggregate]):
             (g.end_time - g.start_time).total_seconds() / 3600.0 for g in games
         ]
 
-        distribution = _build_histogram(durations, _BUCKET_COUNT)
-
         victory_dist: dict[str, int] = {}
         for g in games:
             victory_dist[g.victory_type] = victory_dist.get(g.victory_type, 0) + 1
@@ -53,8 +51,7 @@ class GlobalAggregator(BaseAggregator[GlobalAggregate]):
                 defeated = sum(1 for p in human if p.is_defeated)
                 dropout_rates.append(defeated / len(human))
 
-        # avg_game_days from duration (day ≈ 4h real time in CoN speed 1)
-        # Use day_of_game when available (> 1), otherwise estimate from duration
+        # Use actual game_days when available (> 1), otherwise estimate from duration (day ≈ 4h real time)
         game_days_list = []
         for g in games:
             if g.game_days > 1:
@@ -63,7 +60,12 @@ class GlobalAggregator(BaseAggregator[GlobalAggregate]):
                 hours = (g.end_time - g.start_time).total_seconds() / 3600.0
                 game_days_list.append(hours / 4.0)
 
+        distribution = _build_histogram(game_days_list, _BUCKET_COUNT)
+
         update_intervals = [g.avg_update_interval_seconds for g in games if g.avg_update_interval_seconds > 0]
+
+        def _mean(lst: list) -> float:
+            return statistics.mean(lst) if lst else 0.0
 
         return GlobalAggregate(
             total_games=len(games),
@@ -78,6 +80,10 @@ class GlobalAggregator(BaseAggregator[GlobalAggregate]):
             avg_dropout_rate=statistics.mean(dropout_rates) if dropout_rates else 0.0,
             avg_game_days=statistics.mean(game_days_list) if game_days_list else 0.0,
             avg_update_interval_seconds=statistics.mean(update_intervals) if update_intervals else 0.0,
+            avg_wars_per_game=_mean([g.total_wars_declared for g in games]),
+            avg_peace_treaties_per_game=_mean([g.total_peace_treaties for g in games]),
+            avg_alliances_per_game=_mean([g.total_alliances_formed for g in games]),
+            avg_right_of_ways_per_game=_mean([g.total_right_of_ways for g in games]),
         )
 
 
@@ -87,7 +93,7 @@ def _build_histogram(values: list[float], n_buckets: int) -> list[DurationBucket
     lo = min(values)
     hi = max(values)
     if hi == lo:
-        return [DurationBucket(min_hours=lo, max_hours=hi, count=len(values))]
+        return [DurationBucket(min_days=lo, max_days=hi, count=len(values))]
     width = (hi - lo) / n_buckets
     buckets: list[DurationBucket] = []
     for i in range(n_buckets):
@@ -98,5 +104,5 @@ def _build_histogram(values: list[float], n_buckets: int) -> list[DurationBucket
             count = sum(1 for v in values if b_lo <= v < b_hi)
         else:
             count = sum(1 for v in values if b_lo <= v <= b_hi)
-        buckets.append(DurationBucket(min_hours=round(b_lo, 1), max_hours=round(b_hi, 1), count=count))
+        buckets.append(DurationBucket(min_days=round(b_lo, 1), max_days=round(b_hi, 1), count=count))
     return buckets

--- a/tools/game_stats_extractor/src/game_stats_extractor/aggregators/timeseries_aggregator.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/aggregators/timeseries_aggregator.py
@@ -1,0 +1,75 @@
+"""Section 1.4 — per-country province-count time series, averaged across all games."""
+import statistics
+from collections import defaultdict
+from datetime import datetime
+
+from .base import BaseAggregator
+from ..models.aggregates import CountryTimeSeries, TimeSeriesOutput, TimeSeriesPoint
+from ..models.intermediate import GameData, PlayerData
+
+_PCT_BUCKETS = list(range(0, 101, 5))
+
+
+class TimeSeriesAggregator(BaseAggregator[TimeSeriesOutput]):
+    def __init__(self, min_games: int = 3):
+        self._min_games = min_games
+
+    def aggregate(self, games: list[GameData]) -> TimeSeriesOutput:
+        by_nation: dict[str, list[tuple[GameData, PlayerData]]] = defaultdict(list)
+        for game in games:
+            for player in game.players:
+                by_nation[player.nation_name].append((game, player))
+
+        countries: list[CountryTimeSeries] = []
+        max_game_days = 0
+
+        for nation_name, entries in by_nation.items():
+            if len(entries) < self._min_games:
+                continue
+
+            pct_series = _aggregate_buckets(
+                [p.pct_buckets for _, p in entries], _PCT_BUCKETS
+            )
+
+            all_day_keys: set[int] = set()
+            for _, p in entries:
+                all_day_keys.update(p.day_buckets.keys())
+            day_series = _aggregate_buckets(
+                [p.day_buckets for _, p in entries], sorted(all_day_keys)
+            )
+
+            if all_day_keys:
+                max_game_days = max(max_game_days, max(all_day_keys))
+
+            countries.append(CountryTimeSeries(
+                nation_name=nation_name,
+                games_played=len(entries),
+                pct_game=pct_series,
+                game_days=day_series,
+            ))
+
+        countries.sort(key=lambda c: c.games_played, reverse=True)
+
+        return TimeSeriesOutput(
+            countries=countries,
+            pct_buckets=_PCT_BUCKETS,
+            max_game_days=max_game_days,
+            generated_at=datetime.utcnow(),
+        )
+
+
+def _aggregate_buckets(
+    player_buckets: list[dict[int, int]],
+    bucket_keys: list[int],
+) -> list[TimeSeriesPoint]:
+    points: list[TimeSeriesPoint] = []
+    for b in bucket_keys:
+        values = [pb[b] for pb in player_buckets if b in pb]
+        if not values:
+            continue
+        points.append(TimeSeriesPoint(
+            bucket=b,
+            avg_provinces=round(statistics.mean(values), 2),
+            games_sampled=len(values),
+        ))
+    return points

--- a/tools/game_stats_extractor/src/game_stats_extractor/extractors/replay_extractor.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/extractors/replay_extractor.py
@@ -10,6 +10,9 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Optional
 
+from conflict_interface.data_types.newest.foreign_affairs_state.foreign_affairs_state_enums import (
+    ForeignAffairRelationTypes,
+)
 from conflict_interface.hook_system.replay_hook_tag import ReplayHookTag
 from conflict_interface.interface.replay_interface import ReplayInterface
 
@@ -24,6 +27,22 @@ _UNOWNED = 0
 def _is_land_province(province) -> bool:
     """True for LandProvince objects (which have owner_id / morale)."""
     return hasattr(province, "owner_id") and hasattr(province, "morale")
+
+
+def _pct_bucket(elapsed: float, total: float) -> int:
+    if total <= 0:
+        return 0
+    return max(0, min(100, round((elapsed / total) * 100 / 5) * 5))
+
+
+def _day_bucket(elapsed: float, total: float, game_days: int) -> int:
+    if total <= 0 or game_days <= 0:
+        return 0
+    return round((elapsed / total) * game_days)
+
+
+def _finalize_buckets(sums: dict[int, float], ns: dict[int, int]) -> dict[int, int]:
+    return {b: round(sums[b] / ns[b]) for b in sums if ns[b] > 0}
 
 
 class ReplayExtractor(BaseExtractor):
@@ -150,8 +169,24 @@ class ReplayExtractor(BaseExtractor):
                 player_prov_max[player_id] = cnt
                 player_prov_min[player_id] = cnt
 
-        # ---- Register hooks — only changed provinces fire events ----
+        # Time-series bucket accumulators
+        total_duration_seconds = (end_time - start_time).total_seconds()
+        pct_bucket_sum: dict[int, dict[int, float]] = defaultdict(lambda: defaultdict(float))
+        pct_bucket_n: dict[int, dict[int, int]] = defaultdict(lambda: defaultdict(int))
+        day_bucket_sum: dict[int, dict[int, float]] = defaultdict(lambda: defaultdict(float))
+        day_bucket_n: dict[int, dict[int, int]] = defaultdict(lambda: defaultdict(int))
+
+        # Diplomacy counters — keyed by 1-indexed player id; populated by ForeignAffairsChanged events
+        dp_wars: dict[int, int] = defaultdict(int)
+        dp_peace: dict[int, int] = defaultdict(int)
+        dp_alliances: dict[int, int] = defaultdict(int)
+        dp_allianced: dict[int, int] = defaultdict(int)
+        dp_rows: dict[int, int] = defaultdict(int)
+        game_wars = game_peace = game_alliances = game_allianced = game_rows = 0
+
+        # ---- Register hooks — only changed provinces/relations fire events ----
         replay.register_province_trigger(["owner_id", "morale"])
+        replay.register_foreign_affairs_trigger()
 
         # ---- Iterate all timestamps ----
         while replay.jump_to_next_patch():
@@ -185,7 +220,50 @@ class ReplayExtractor(BaseExtractor):
                             prov_morale_min[pid] = morale
                             prov_morale_max[pid] = morale
 
+            # Diplomacy — one event per tick when neighbor_relations changed;
+            # extractor diffs old vs new to classify per-(sender, receiver) transitions.
+            # Use .value comparisons: game state enums may come from a versioned module
+            # (e.g. data_types.v210) while the extractor imports from data_types.newest —
+            # different classes, so == fails even for identical members.
+            _war_val = ForeignAffairRelationTypes.WAR.value
+            _peace_val = ForeignAffairRelationTypes.PEACE.value
+            _mutual_val = ForeignAffairRelationTypes.MUTUAL_PROTECTION.value
+            _row_val = ForeignAffairRelationTypes.RIGHT_OF_WAY.value
+            for fa_event in events.get(ReplayHookTag.ForeignAffairsRelationChanged, []):
+                old_rel, new_rel = fa_event.attributes["neighbor_relations"]
+                if old_rel is None or new_rel is None:
+                    continue
+                for s in set(old_rel) | set(new_rel):
+                    prev_row = old_rel.get(s, {})
+                    curr_row = new_rel.get(s, {})
+                    for r in set(prev_row) | set(curr_row):
+                        old_v = prev_row.get(r)
+                        new_v = curr_row.get(r)
+                        old_val = old_v.value if old_v is not None else _peace_val
+                        new_val = new_v.value if new_v is not None else _peace_val
+                        if old_val == new_val:
+                            continue
+                        sender_id = s + 1
+                        if new_val == _war_val:
+                            dp_wars[sender_id] += 1
+                            game_wars += 1
+                        elif old_val == _war_val and new_val >= _peace_val:
+                            dp_peace[sender_id] += 1
+                            game_peace += 1
+                        if new_val == _mutual_val:
+                            dp_alliances[sender_id] += 1
+                            game_alliances += 1
+                        elif old_val == _mutual_val:
+                            dp_allianced[sender_id] += 1
+                            game_allianced += 1
+                        if new_val == _row_val:
+                            dp_rows[sender_id] += 1
+                            game_rows += 1
+
             # Snapshot player territory counts — O(players), not O(provinces)
+            ct = replay.current_time
+            pb = _pct_bucket((ct - start_time).total_seconds(), total_duration_seconds) if ct else 0
+            db = _day_bucket((ct - start_time).total_seconds(), total_duration_seconds, game_days) if ct else 0
             for player_id, cnt in current_player_counts.items():
                 if cnt <= 0:
                     continue
@@ -196,6 +274,10 @@ class ReplayExtractor(BaseExtractor):
                     player_prov_min[player_id] = min(player_prov_min[player_id], cnt)
                 else:
                     player_prov_min[player_id] = cnt
+                pct_bucket_sum[player_id][pb] += cnt
+                pct_bucket_n[player_id][pb] += 1
+                day_bucket_sum[player_id][db] += cnt
+                day_bucket_n[player_id][db] += 1
 
         # ---- Final state — game_state accessed once, only for production values ----
         gs = replay.game_state
@@ -238,6 +320,13 @@ class ReplayExtractor(BaseExtractor):
                 avg_province_count=player_prov_sum.get(player_id, 0) / n,
                 provinces_captured=player_captures.get(player_id, 0),
                 provinces_lost=player_losses.get(player_id, 0),
+                pct_buckets=_finalize_buckets(pct_bucket_sum[player_id], pct_bucket_n[player_id]),
+                day_buckets=_finalize_buckets(day_bucket_sum[player_id], day_bucket_n[player_id]),
+                wars_declared=dp_wars.get(player_id, 0),
+                peace_treaties_signed=dp_peace.get(player_id, 0),
+                alliances_formed=dp_alliances.get(player_id, 0),
+                alliance_dissolutions=dp_allianced.get(player_id, 0),
+                right_of_ways_signed=dp_rows.get(player_id, 0),
             ))
 
         # ---- Victory detection ----
@@ -278,6 +367,11 @@ class ReplayExtractor(BaseExtractor):
             game_ended=True,  # guaranteed by early exit in extract()
             players=players,
             provinces=provinces,
+            total_wars_declared=game_wars,
+            total_peace_treaties=game_peace,
+            total_alliances_formed=game_alliances,
+            total_alliance_dissolutions=game_allianced,
+            total_right_of_ways=game_rows,
         )
 
 

--- a/tools/game_stats_extractor/src/game_stats_extractor/models/aggregates.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/models/aggregates.py
@@ -9,8 +9,8 @@ from pydantic import BaseModel
 
 
 class DurationBucket(BaseModel):
-    min_hours: float
-    max_hours: float
+    min_days: float
+    max_days: float
     count: int
 
 
@@ -28,6 +28,10 @@ class GlobalAggregate(BaseModel):
     avg_dropout_rate: float
     avg_game_days: float
     avg_update_interval_seconds: float
+    avg_wars_per_game: float = 0.0
+    avg_peace_treaties_per_game: float = 0.0
+    avg_alliances_per_game: float = 0.0
+    avg_right_of_ways_per_game: float = 0.0
 
 
 class CountryAggregate(BaseModel):
@@ -46,6 +50,10 @@ class CountryAggregate(BaseModel):
     avg_provinces_lost: float
     elimination_rate: float
     avg_survival_days: float
+    avg_wars_declared: float = 0.0
+    avg_peace_treaties_signed: float = 0.0
+    avg_alliances_formed: float = 0.0
+    avg_right_of_ways_signed: float = 0.0
 
 
 class ProvinceAggregate(BaseModel):
@@ -62,6 +70,26 @@ class ProvinceAggregate(BaseModel):
     avg_resource_production: float
     avg_money_production: float
     avg_morale: float
+
+
+class TimeSeriesPoint(BaseModel):
+    bucket: int
+    avg_provinces: float
+    games_sampled: int
+
+
+class CountryTimeSeries(BaseModel):
+    nation_name: str
+    games_played: int
+    pct_game: list[TimeSeriesPoint]
+    game_days: list[TimeSeriesPoint]
+
+
+class TimeSeriesOutput(BaseModel):
+    countries: list[CountryTimeSeries]
+    pct_buckets: list[int]
+    max_game_days: int
+    generated_at: datetime
 
 
 class MetaInfo(BaseModel):

--- a/tools/game_stats_extractor/src/game_stats_extractor/models/intermediate.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/models/intermediate.py
@@ -23,6 +23,13 @@ class PlayerData:
     avg_province_count: float
     provinces_captured: int = 0
     provinces_lost: int = 0
+    pct_buckets: dict[int, int] = field(default_factory=dict)
+    day_buckets: dict[int, int] = field(default_factory=dict)
+    wars_declared: int = 0
+    peace_treaties_signed: int = 0
+    alliances_formed: int = 0
+    alliance_dissolutions: int = 0
+    right_of_ways_signed: int = 0
 
 
 @dataclass
@@ -57,3 +64,8 @@ class GameData:
     game_ended: bool
     players: list[PlayerData] = field(default_factory=list)
     provinces: list[ProvinceData] = field(default_factory=list)
+    total_wars_declared: int = 0
+    total_peace_treaties: int = 0
+    total_alliances_formed: int = 0
+    total_alliance_dissolutions: int = 0
+    total_right_of_ways: int = 0

--- a/tools/game_stats_extractor/src/game_stats_extractor/output.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/output.py
@@ -2,8 +2,9 @@
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
-from .models.aggregates import CountryAggregate, GlobalAggregate, MetaInfo, ProvinceAggregate
+from .models.aggregates import CountryAggregate, GlobalAggregate, MetaInfo, ProvinceAggregate, TimeSeriesOutput
 from .models.intermediate import GameData
 
 
@@ -13,11 +14,86 @@ def _default(obj):
     raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 
+def _r(v) -> float | int:
+    return round(v, 2) if isinstance(v, float) else v
+
+
+def _rp(v) -> float:
+    """Higher-precision rounding for proportion/rate fields used in scatter plots."""
+    return round(v, 4)
+
+
+def _provinces_columnar(provinces: list[ProvinceAggregate]) -> dict:
+    cols = [
+        "province_id", "province_name", "terrain_type", "is_coastal",
+        "games_appeared", "avg_ownership_changes", "contest_frequency",
+        "win_correlation", "resource_production_type",
+        "avg_resource_production", "avg_money_production", "avg_morale",
+    ]
+    rows = [
+        [
+            p.province_id, p.province_name, p.terrain_type, p.is_coastal,
+            p.games_appeared, _r(p.avg_ownership_changes), _rp(p.contest_frequency),
+            _rp(p.win_correlation), p.resource_production_type,
+            _r(p.avg_resource_production), _r(p.avg_money_production), _r(p.avg_morale),
+        ]
+        for p in provinces
+    ]
+    return {"columns": cols, "rows": rows}
+
+
+def _countries_columnar(countries: list[CountryAggregate]) -> dict:
+    cols = [
+        "nation_name", "games_played", "wins", "win_rate", "avg_final_vp",
+        "avg_placement", "median_placement", "avg_final_provinces",
+        "avg_initial_provinces", "avg_expansion", "avg_provinces_captured",
+        "avg_provinces_lost", "elimination_rate", "avg_survival_days",
+    ]
+    rows = [
+        [
+            c.nation_name, c.games_played, c.wins, _r(c.win_rate), _r(c.avg_final_vp),
+            _r(c.avg_placement), _r(c.median_placement), _r(c.avg_final_provinces),
+            _r(c.avg_initial_provinces), _r(c.avg_expansion),
+            _r(c.avg_provinces_captured), _r(c.avg_provinces_lost),
+            _r(c.elimination_rate), _r(c.avg_survival_days),
+        ]
+        for c in countries
+    ]
+    return {"columns": cols, "rows": rows}
+
+
+def _timeseries_compact(ts: TimeSeriesOutput) -> dict:
+    n_days = ts.max_game_days + 1
+    countries = []
+    for c in ts.countries:
+        pct_by_bucket = {p.bucket: p for p in c.pct_game}
+        day_by_bucket = {p.bucket: p for p in c.game_days}
+        pct_avg = [_r(pct_by_bucket[b].avg_provinces) if b in pct_by_bucket else None for b in ts.pct_buckets]
+        pct_n   = [pct_by_bucket[b].games_sampled if b in pct_by_bucket else None for b in ts.pct_buckets]
+        day_avg = [_r(day_by_bucket[d].avg_provinces) if d in day_by_bucket else None for d in range(n_days)]
+        day_n   = [day_by_bucket[d].games_sampled if d in day_by_bucket else None for d in range(n_days)]
+        countries.append({
+            "nation_name": c.nation_name,
+            "games_played": c.games_played,
+            "pct_avg": pct_avg,
+            "pct_n": pct_n,
+            "day_avg": day_avg,
+            "day_n": day_n,
+        })
+    return {
+        "pct_buckets": ts.pct_buckets,
+        "max_game_days": ts.max_game_days,
+        "generated_at": ts.generated_at.isoformat(),
+        "countries": countries,
+    }
+
+
 def write_output(
     output_dir: Path,
     global_agg: GlobalAggregate,
     country_aggs: list[CountryAggregate],
     province_aggs: list[ProvinceAggregate],
+    timeseries_agg: TimeSeriesOutput,
     games: list[GameData],
     replay_dir: Path,
     failed_replays: int,
@@ -34,10 +110,19 @@ def write_output(
         date_range_end=max(start_times) if start_times else None,
     )
 
+    # Large files: compact columnar format, no indentation
+    _write_compact(output_dir / "provinces.json",  _provinces_columnar(province_aggs))
+    _write_compact(output_dir / "countries.json",  _countries_columnar(country_aggs))
+    _write_compact(output_dir / "timeseries.json", _timeseries_compact(timeseries_agg))
+
+    # Small files: readable indented JSON
     _write_json(output_dir / "global.json", global_agg.model_dump())
-    _write_json(output_dir / "countries.json", [c.model_dump() for c in country_aggs])
-    _write_json(output_dir / "provinces.json", [p.model_dump() for p in province_aggs])
     _write_json(output_dir / "meta.json", meta.model_dump())
+
+
+def _write_compact(path: Path, data) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, separators=(",", ":"), default=_default)
 
 
 def _write_json(path: Path, data) -> None:

--- a/tools/game_stats_extractor/src/game_stats_extractor/output.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/output.py
@@ -48,6 +48,8 @@ def _countries_columnar(countries: list[CountryAggregate]) -> dict:
         "avg_placement", "median_placement", "avg_final_provinces",
         "avg_initial_provinces", "avg_expansion", "avg_provinces_captured",
         "avg_provinces_lost", "elimination_rate", "avg_survival_days",
+        "avg_wars_declared", "avg_peace_treaties_signed",
+        "avg_alliances_formed", "avg_right_of_ways_signed",
     ]
     rows = [
         [
@@ -56,6 +58,8 @@ def _countries_columnar(countries: list[CountryAggregate]) -> dict:
             _r(c.avg_initial_provinces), _r(c.avg_expansion),
             _r(c.avg_provinces_captured), _r(c.avg_provinces_lost),
             _r(c.elimination_rate), _r(c.avg_survival_days),
+            _r(c.avg_wars_declared), _r(c.avg_peace_treaties_signed),
+            _r(c.avg_alliances_formed), _r(c.avg_right_of_ways_signed),
         ]
         for c in countries
     ]

--- a/tools/game_stats_extractor/src/game_stats_extractor/pipeline.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/pipeline.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 from .aggregators.country_aggregator import CountryAggregator
 from .aggregators.global_aggregator import GlobalAggregator
 from .aggregators.province_aggregator import ProvinceAggregator
+from .aggregators.timeseries_aggregator import TimeSeriesAggregator
 from .extractors.replay_extractor import ReplayExtractor
 from .models.intermediate import GameData
 from .output import write_output
@@ -37,12 +38,14 @@ class Pipeline:
         workers: int = os.cpu_count() or 1,
         map_data_dir: Optional[Path] = None,
         min_province_appearances: int = 3,
+        min_timeseries_games: int = 3,
     ):
         self.replays_dir = replays_dir
         self.output_dir = output_dir
         self.workers = workers
         self.map_data_dir = map_data_dir
         self.min_province_appearances = min_province_appearances
+        self.min_timeseries_games = min_timeseries_games
 
     def run(self) -> None:
         replay_files = sorted(self.replays_dir.glob("game_*.conrp"))
@@ -81,6 +84,9 @@ class Pipeline:
         logger.info("Aggregating province statistics (min appearances=%d)...", self.min_province_appearances)
         province_aggs = ProvinceAggregator(min_appearances=self.min_province_appearances).aggregate(games)
 
+        logger.info("Aggregating time series...")
+        timeseries_agg = TimeSeriesAggregator(min_games=self.min_timeseries_games).aggregate(games)
+
         logger.info(
             "Writing output: %d countries, %d provinces",
             len(country_aggs),
@@ -91,6 +97,7 @@ class Pipeline:
             global_agg,
             country_aggs,
             province_aggs,
+            timeseries_agg,
             games,
             self.replays_dir,
             failed,


### PR DESCRIPTION
This pull request introduces several new data visualization components and supporting logic for country and province statistics in the documentation app. It adds new chart components for visualizing country diplomacy, province strategic value, country radar comparisons, and global diplomacy metrics, as well as deserialization utilities for handling statistical data. It also updates existing sections to include these new charts and makes a minor label change to the game duration chart.

**New Chart Components:**

* Added `CountryDiplomacyChart` for visualizing average wars declared, peace treaties, alliances, and right-of-ways per country, including tooltip breakdowns.
* Added `CountryRadarChart` for normalized radar comparison of top countries across multiple dimensions (win rate, expansion, aggression, survival, territory).
* Added `DiplomacyGlobalChart` for displaying global averages of diplomatic actions per game.
* Added `ProvinceStrategicScatterChart` to visualize the strategic value of provinces by contest frequency and win correlation, with terrain coloring and outlier labeling.
* Added `CountryProvincesTimeSeriesChart` for time series visualization of province control by country, with toggleable modes for percent of game or game days.

**Data Handling and Integration:**

* Introduced deserialization utilities in `deserialize.ts` to convert raw columnar/statistical data into structured types for use in charts.
* Updated `CountryStatsSection` and `GlobalStatsSection` to import and render the new chart components. [[1]](diffhunk://#diff-cedda3b92800e94a5bd2b0f9b6c0057c801aa4e197e04f02267b9d0864dfc767R3) [[2]](diffhunk://#diff-cedda3b92800e94a5bd2b0f9b6c0057c801aa4e197e04f02267b9d0864dfc767R58-R62) [[3]](diffhunk://#diff-b6ffdee5c72915ef951a7260a5b77b7beb027c3b01d9d6657d1d40d54eb543cdR2)

**Minor Improvements:**

* Changed the label in `GameDurationChart` from hours to days for better clarity.