### PR TITLE
Implement server outage tracking and recovery probe

### DIFF
--- a/infra/prod/alerts.yml
+++ b/infra/prod/alerts.yml
@@ -65,3 +65,32 @@ groups:
         annotations:
           summary: "Observer has no active game recordings"
           description: "No games have been active for 30 minutes. This may be normal off-peak, or the observer may be stuck."
+
+      - alert: ObserverGameServerDown
+        expr: server_observer_down_server_count > 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $value }} game server address(es) unreachable — sessions frozen"
+          description: "Per-address circuit breaker is open. Retry budgets are not consumed; sessions will auto-resume when the recovery probe confirms the server is reachable again."
+
+      - alert: ObserverRedisPublishFailures
+        expr: rate(server_observer_redis_publish_failures_total[5m]) > 0
+        for: 3m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Observer cannot publish game responses to Redis"
+          description: "Game state is being fetched but not forwarded to the converter. Data loss is occurring. Check Redis container health."
+
+  - name: server_converter_extended
+    rules:
+      - alert: ConverterHighConsumerLag
+        expr: server_converter_redis_consumer_lag > 5000
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Converter Redis consumer lag is high ({{ $value }} messages)"
+          description: "Stream cap is ~50,000 entries. At this lag, message loss risk is elevated if the converter stays behind."

--- a/services/server_observer/src/connectivity_check.rs
+++ b/services/server_observer/src/connectivity_check.rs
@@ -71,7 +71,7 @@ pub fn is_socks5_ruleset_error(message: &str) -> bool {
     message.contains("0x02") || message.contains("Connection not allowed by ruleset")
 }
 
-async fn check_direct(url: &str) -> bool {
+pub(crate) async fn check_direct(url: &str) -> bool {
     let client = match Client::builder()
         .no_proxy()
         .timeout(CHECK_TIMEOUT)

--- a/services/server_observer/src/main.rs
+++ b/services/server_observer/src/main.rs
@@ -14,6 +14,7 @@ mod redis_publisher;
 mod s3_client;
 mod scheduler;
 mod server_observer;
+mod server_outage_tracker;
 mod static_map_cache;
 
 use crate::hub_interface_wrapper::HubInterfaceWrapper;

--- a/services/server_observer/src/metrics.rs
+++ b/services/server_observer/src/metrics.rs
@@ -159,6 +159,30 @@ static HTTP_RESPONSE_SIZE_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
     vec
 });
 
+static DOWN_SERVER_COUNT: Lazy<IntGauge> = Lazy::new(|| {
+    let opts = Opts::new(
+        "server_observer_down_server_count",
+        "Number of game-server addresses with an open circuit breaker (currently unreachable)",
+    );
+    let gauge = IntGauge::with_opts(opts).expect("create server_observer_down_server_count");
+    default_registry()
+        .register(Box::new(gauge.clone()))
+        .expect("register server_observer_down_server_count");
+    gauge
+});
+
+static REDIS_PUBLISH_FAILURES_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    let opts = Opts::new(
+        "server_observer_redis_publish_failures_total",
+        "Total number of failed Redis XADD calls (game responses lost due to Redis unavailability)",
+    );
+    let counter = IntCounter::with_opts(opts).expect("create server_observer_redis_publish_failures_total");
+    default_registry()
+        .register(Box::new(counter.clone()))
+        .expect("register server_observer_redis_publish_failures_total");
+    counter
+});
+
 // Public helpers used by the rest of the crate
 pub fn record_game_started(scenario_id: i32) {
     GAMES_STARTED_TOTAL
@@ -220,6 +244,14 @@ pub fn record_response_size(bytes: usize) {
     HTTP_RESPONSE_SIZE_BYTES
         .with_label_values(&["true"])
         .observe(bytes as f64);
+}
+
+pub fn set_down_server_count(n: i64) {
+    DOWN_SERVER_COUNT.set(n);
+}
+
+pub fn record_redis_publish_failure() {
+    REDIS_PUBLISH_FAILURES_TOTAL.inc();
 }
 
 pub struct MetricsServer {

--- a/services/server_observer/src/observation_session.rs
+++ b/services/server_observer/src/observation_session.rs
@@ -1,5 +1,6 @@
 use crate::account_pool::{Account, ProxyConfig};
 use crate::hub_interface_wrapper::{HubInterfaceError, HubInterfaceWrapper};
+use crate::metrics::record_redis_publish_failure;
 use crate::observation_api::{GameServerError, GameServerResult, ObservationApi, ObservationApiError};
 use crate::observation_package::ObservationPackage;
 use crate::recording_storage::{RecordingStorage, RecordingStorageError};
@@ -442,6 +443,7 @@ impl ObservationSession {
             .publish_compressed_response(&metadata, &compressed_response)
         {
             tracing::warn!(?err, game_id = self.game_id, "failed redis publish");
+            record_redis_publish_failure();
         }
 
         let pkg_json = self.package.to_json();

--- a/services/server_observer/src/scheduler.rs
+++ b/services/server_observer/src/scheduler.rs
@@ -46,6 +46,21 @@ impl Scheduler {
         self.stop_flag.store(true, Ordering::SeqCst);
     }
 
+    /// Schedules `game_id` for an immediate update without requiring a session reference.
+    /// Used by the recovery probe to resume frozen sessions after a server comes back up.
+    pub fn schedule_immediate_by_id(&self, game_id: i32) {
+        let now = SystemTime::now();
+        self.update_queue
+            .lock()
+            .unwrap_or_else(|poisoned| {
+                tracing::error!("scheduler queue mutex poisoned; recovering");
+                poisoned.into_inner()
+            })
+            .entry(now)
+            .or_default()
+            .push_back(game_id);
+    }
+
     pub fn schedule_update(&self, session: &ObservationSession) {
         let mut queue = self.update_queue.lock().unwrap_or_else(|poisoned| { tracing::error!("scheduler queue mutex poisoned; recovering"); poisoned.into_inner() });
         queue

--- a/services/server_observer/src/server_observer.rs
+++ b/services/server_observer/src/server_observer.rs
@@ -5,8 +5,9 @@ use crate::game_finder::{GameFinder, GameFinderConfig};
 use crate::metrics::{
     record_game_completed, record_game_failed, record_game_started, record_game_update_retry,
     record_missed_interval, record_scheduled_update_latency, record_game_update_completed,
-    record_game_update_started, set_active_games,
+    record_game_update_started, set_active_games, set_down_server_count,
 };
+use crate::server_outage_tracker::ServerOutageTracker;
 use crate::observation_session::{ObservationError, ObservationResult, ObservationSession};
 use crate::recording_registry::RecordingRegistry;
 use crate::redis_publisher::{RedisConfig, RedisPublisher};
@@ -57,6 +58,7 @@ pub struct ServerObserver {
     redis_publisher: RedisPublisher,
     dead_letter_path: String,
     game_server_status_map: GameServerStatusMap,
+    outage_tracker: ServerOutageTracker,
 }
 
 impl ServerObserver {
@@ -187,6 +189,7 @@ impl ServerObserver {
             redis_publisher,
             dead_letter_path,
             game_server_status_map: GameServerStatusMap::new(),
+            outage_tracker: ServerOutageTracker::new(),
         });
 
         tracing::info!(
@@ -225,6 +228,46 @@ impl ServerObserver {
         );
 
         self.resume_active().await;
+
+        // Spawn the recovery probe: periodically re-checks any down server addresses
+        // and resumes frozen sessions when they become reachable again.
+        {
+            let weak = Arc::downgrade(&self);
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    let Some(observer) = weak.upgrade() else { break };
+                    if observer.stop_flag.load(Ordering::SeqCst) { break; }
+
+                    for addr in observer.outage_tracker.down_addresses() {
+                        let reachable = connectivity_check::check_direct(&addr).await;
+                        observer.game_server_status_map.update(&addr, reachable);
+                        if reachable {
+                            let frozen = observer.outage_tracker.close(&addr);
+                            set_down_server_count(observer.outage_tracker.down_count());
+                            tracing::info!(
+                                server_addr = %addr,
+                                game_count = frozen.len(),
+                                "game server recovered; resuming frozen sessions"
+                            );
+                            for game_id in frozen {
+                                let session_arc = {
+                                    observer.observer_sessions
+                                        .lock()
+                                        .unwrap_or_else(|p| { tracing::error!("observer sessions mutex poisoned; recovering"); p.into_inner() })
+                                        .get(&game_id)
+                                        .cloned()
+                                };
+                                let Some(session_arc) = session_arc else { continue };
+                                session_arc.lock().await.reset_attempt();
+                                observer.scheduler.schedule_immediate_by_id(game_id);
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
         {
             let mut guard = self.game_finder.lock().unwrap_or_else(|poisoned| { tracing::error!("game finder mutex poisoned; recovering"); poisoned.into_inner() });
             if let Some(game_finder) = guard.as_mut() {
@@ -589,7 +632,7 @@ impl ServerObserver {
         result: ObservationResult,
     ) {
         // Phase 1: collect everything needed without holding the session lock during async work.
-        let (username, proxy_url, game_server_address, current_attempt) = {
+        let (username, proxy_url, game_server_address, _current_attempt) = {
             let session = session_arc.lock().await;
             let game_server = if session.last_game_server_address.is_empty() {
                 None
@@ -604,10 +647,26 @@ impl ServerObserver {
             )
         };
 
-        // Phase 2: run connectivity diagnostics on the first NetworkError (no locks held).
+        // Derive the server-address key used for circuit-breaker lookups throughout.
+        let server_addr = game_server_address
+            .clone()
+            .unwrap_or_else(|| connectivity_check::FALLBACK_GAME_SERVER_URL.to_string());
+
+        // Fast path: circuit already open for this server — freeze without diagnosis and without
+        // burning the retry budget. The recovery probe will resume the session when the server
+        // is reachable again.
+        if self.outage_tracker.is_down(&server_addr) {
+            self.outage_tracker.freeze(&server_addr, game_id);
+            let mut session = session_arc.lock().await;
+            self.scheduler.schedule_retry_update(&mut session, Duration::from_secs(60));
+            tracing::debug!(game_id, server_addr, "session re-frozen; circuit still open for server");
+            return;
+        }
+
+        // Phase 2: run connectivity diagnostics on NetworkError when the circuit is not already open.
         let mut needs_proxy_replace = false;
         let effective_error = if result.error_code == ObservationError::NetworkError
-            && current_attempt == 1
+            && !self.outage_tracker.is_down(&server_addr)
         {
             let diagnosis = connectivity_check::diagnose(
                 &proxy_url,
@@ -619,11 +678,18 @@ impl ServerObserver {
 
             match diagnosis {
                 connectivity_check::NetworkDiagnosis::GameServerDown => {
-                    tracing::warn!(
-                        game_id,
-                        "game server appears globally down; downgrading to ServerError semantics"
-                    );
-                    ObservationError::ServerError
+                    let newly_opened = self.outage_tracker.open(&server_addr, game_id);
+                    if newly_opened {
+                        set_down_server_count(self.outage_tracker.down_count());
+                        tracing::warn!(
+                            game_id,
+                            server_addr,
+                            "circuit opened; game server unreachable — sessions frozen until recovery probe clears it"
+                        );
+                    }
+                    let mut session = session_arc.lock().await;
+                    self.scheduler.schedule_retry_update(&mut session, Duration::from_secs(60));
+                    return;
                 }
                 connectivity_check::NetworkDiagnosis::ProxyDead
                 | connectivity_check::NetworkDiagnosis::ProxyBlockingTarget => {

--- a/services/server_observer/src/server_outage_tracker.rs
+++ b/services/server_observer/src/server_outage_tracker.rs
@@ -1,0 +1,102 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+/// Tracks which game-server addresses are currently known-down and which
+/// game sessions are frozen waiting for them to recover.
+///
+/// When a connectivity diagnosis returns `GameServerDown` for a specific
+/// address (e.g. `congs16.c.bytro.com`), the circuit for that address is
+/// opened. All sessions on that address are frozen — their retry budgets are
+/// not decremented — until the recovery probe finds the server reachable again.
+pub struct ServerOutageTracker {
+    /// address → set of frozen game_ids
+    down_servers: Mutex<HashMap<String, HashSet<i32>>>,
+}
+
+impl ServerOutageTracker {
+    pub fn new() -> Self {
+        Self {
+            down_servers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns `true` if `addr` currently has an open circuit.
+    pub fn is_down(&self, addr: &str) -> bool {
+        self.down_servers
+            .lock()
+            .unwrap_or_else(|p| {
+                tracing::error!("outage tracker mutex poisoned; recovering");
+                p.into_inner()
+            })
+            .contains_key(addr)
+    }
+
+    /// Opens the circuit for `addr` and records `game_id` as the first frozen session.
+    ///
+    /// Returns `true` if this was the first time `addr` was added (newly opened circuit),
+    /// `false` if it was already open (duplicate open for same address).
+    pub fn open(&self, addr: &str, game_id: i32) -> bool {
+        let mut map = self
+            .down_servers
+            .lock()
+            .unwrap_or_else(|p| {
+                tracing::error!("outage tracker mutex poisoned; recovering");
+                p.into_inner()
+            });
+        let newly_opened = !map.contains_key(addr);
+        map.entry(addr.to_string()).or_default().insert(game_id);
+        newly_opened
+    }
+
+    /// Adds `game_id` to the frozen set of an already-open circuit for `addr`.
+    /// No-ops if `addr` is not currently down.
+    pub fn freeze(&self, addr: &str, game_id: i32) {
+        let mut map = self
+            .down_servers
+            .lock()
+            .unwrap_or_else(|p| {
+                tracing::error!("outage tracker mutex poisoned; recovering");
+                p.into_inner()
+            });
+        if let Some(set) = map.get_mut(addr) {
+            set.insert(game_id);
+        }
+    }
+
+    /// Closes the circuit for `addr` and returns the full set of frozen game_ids.
+    /// Returns an empty set if `addr` was not tracked.
+    pub fn close(&self, addr: &str) -> HashSet<i32> {
+        self.down_servers
+            .lock()
+            .unwrap_or_else(|p| {
+                tracing::error!("outage tracker mutex poisoned; recovering");
+                p.into_inner()
+            })
+            .remove(addr)
+            .unwrap_or_default()
+    }
+
+    /// Returns all currently-down server addresses. Used by the recovery probe.
+    pub fn down_addresses(&self) -> Vec<String> {
+        self.down_servers
+            .lock()
+            .unwrap_or_else(|p| {
+                tracing::error!("outage tracker mutex poisoned; recovering");
+                p.into_inner()
+            })
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    /// Returns the number of currently-down server addresses.
+    pub fn down_count(&self) -> i64 {
+        self.down_servers
+            .lock()
+            .unwrap_or_else(|p| {
+                tracing::error!("outage tracker mutex poisoned; recovering");
+                p.into_inner()
+            })
+            .len() as i64
+    }
+}


### PR DESCRIPTION
This pull request introduces a robust circuit breaker and recovery mechanism to the `server_observer` service, improving its resilience to game server outages and Redis failures. The main changes include tracking unreachable game server addresses, freezing and resuming observation sessions accordingly, and exposing new metrics and alerts for better operational visibility.

Key changes:

**Circuit breaker for game servers and session freezing:**
- Added a new `ServerOutageTracker` component to track unreachable game server addresses and freeze affected observation sessions without consuming their retry budgets. Sessions are automatically resumed when the server becomes reachable again, as detected by a periodic recovery probe. (`services/server_observer/src/server_outage_tracker.rs`, `services/server_observer/src/server_observer.rs`, [[1]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR231-R270) [[2]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fL607-R669) [[3]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR681-R692) [[4]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR61) [[5]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR192) [[6]](diffhunk://#diff-2b774efca35efd5dbe89882a3c4fcdca40c41c6c8bbf274c6e93a4f1efbcb3c0R17) [[7]](diffhunk://#diff-26cb4353b5fc5298e7b077c70280815e6587a1b6d37bae934e1ea236630c9a45R49-R63)
- Modified the scheduler to allow immediate rescheduling of sessions by game ID, enabling prompt recovery when a server returns. (`services/server_observer/src/scheduler.rs`, [services/server_observer/src/scheduler.rsR49-R63](diffhunk://#diff-26cb4353b5fc5298e7b077c70280815e6587a1b6d37bae934e1ea236630c9a45R49-R63))

**Operational metrics and alerting:**
- Introduced new Prometheus metrics: `server_observer_down_server_count` (number of unreachable game server addresses) and `server_observer_redis_publish_failures_total` (count of failed Redis publishes). (`services/server_observer/src/metrics.rs`, [[1]](diffhunk://#diff-871ddee1044afb4f8edb76b6dad7ff4ee717d0fe729797165ef5378a2e452aadR162-R185) [[2]](diffhunk://#diff-871ddee1044afb4f8edb76b6dad7ff4ee717d0fe729797165ef5378a2e452aadR249-R256)
- Updated the code to increment these metrics when relevant events occur, such as failed Redis publishes or when a server is marked as down or recovered. (`services/server_observer/src/observation_session.rs`, [[1]](diffhunk://#diff-fae495b197ab18422101d7ca092344b644bf278411cd51fa83d30c7535bea5d8R3) [[2]](diffhunk://#diff-fae495b197ab18422101d7ca092344b644bf278411cd51fa83d30c7535bea5d8R446); `services/server_observer/src/server_observer.rs`, [[3]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fL592-R635)

**Production alerting:**
- Added new critical alerts for when game server addresses are unreachable (circuit breaker open) and when Redis publish failures are detected, as well as a warning for high Redis consumer lag in the converter. (`infra/prod/alerts.yml`, [infra/prod/alerts.ymlR68-R96](diffhunk://#diff-31c29b0b1933a7a48a4f4a4056d574786d21d83dd21ba351735b4aa9f51e6f1aR68-R96))

These changes together ensure that the observer service can handle backend outages gracefully, avoid unnecessary retry exhaustion, and provide clear operational signals for rapid incident response.…dis publish failures, and introduce recovery probe for frozen sessions