### PR TITLE
Add method to reset package and credentials

### DIFF
--- a/services/server_observer/src/observation_session.rs
+++ b/services/server_observer/src/observation_session.rs
@@ -340,6 +340,20 @@ impl ObservationSession {
         self.api = None;
     }
 
+    /// Like `reset_package`, but also discards any persisted resume metadata
+    /// (stale auth/cookies/client_version). Without this, `ensure_observation_package`
+    /// would keep resuming from the same broken saved state on every retry instead of
+    /// performing a fresh hub login + game join, which is what re-derives the live
+    /// client_version (scraped from index.html) and a valid auth session.
+    pub fn reset_package_and_credentials(&mut self) {
+        if let Ok(storage) = self.ensure_storage() {
+            let _ = storage.clear_resume_metadata();
+        }
+        self.hub_interface = None;
+        self.package = ObservationPackage::default();
+        self.api = None;
+    }
+
     async fn ensure_static_map_data(&mut self, map_id: &str) -> bool {
         let Some(map_cache) = &self.map_cache else {
             return false;
@@ -363,12 +377,12 @@ impl ObservationSession {
     fn handle_game_server_error(&mut self, result: &GameServerResult) -> ObservationResult {
         match result.error_code {
             GameServerError::AuthError => {
-                self.reset_package();
+                self.reset_package_and_credentials();
                 ObservationResult::make_auth_failed(false, result.error_message.clone())
             }
             GameServerError::HttpError => {
                 // 4xx — permanent client error, reset so we re-authenticate
-                self.reset_package();
+                self.reset_package_and_credentials();
                 ObservationResult::make_server_error(result.error_message.clone())
             }
             GameServerError::ServerError => {

--- a/services/server_observer/src/recording_storage.rs
+++ b/services/server_observer/src/recording_storage.rs
@@ -112,6 +112,17 @@ impl RecordingStorage {
             .is_some()
     }
 
+    pub fn clear_resume_metadata(&self) -> Result<(), RecordingStorageError> {
+        let metadata_snapshot = {
+            let mut state = self.state.lock().unwrap_or_else(|poisoned| { tracing::error!("recording storage mutex poisoned; recovering"); poisoned.into_inner() });
+            state.metadata_cache["resume"] = Value::Null;
+            state.resume_metadata = Value::Null;
+            state.updates_since_last_flush = 0;
+            state.metadata_cache.clone()
+        };
+        save_metadata_file(&self.metadata_file, &metadata_snapshot)
+    }
+
     pub fn flush_metadata(&self) -> Result<(), RecordingStorageError> {
         let metadata = self
             .state


### PR DESCRIPTION
```
### Summary
Introduced `reset_package_and_credentials` method to clear stale metadata and improve authentication handling.

### Changes
- Added a new method to reset package configurations and credentials.
- Enhanced error handling and metadata refresh logic.
```