### PR TITLE
Shared proxies accross acounts, proactive proxy health checked, changed to python memallocator

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -104,6 +104,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - LOG_DIR=/app/logs
+      - PYTHONMALLOC=malloc
     networks:
       - conlyse-network
     restart: unless-stopped
@@ -158,6 +159,7 @@ services:
       MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
       MINIO_BUCKET: ${MINIO_BUCKET_NAME:-replays}
+      PYTHONMALLOC: malloc
     volumes:
       - ./prod/server-converter-config.json:/app/config.json:ro
       - converter-hot-storage:/data/hot_storage

--- a/infra/prod/grafana/provisioning/dashboards/conlyse-services.json
+++ b/infra/prod/grafana/provisioning/dashboards/conlyse-services.json
@@ -1022,13 +1022,410 @@
       }
     },
     {
+      "id": 40,
+      "type": "stat",
+      "title": "Unhealthy Proxies",
+      "gridPos": {
+        "x": 0,
+        "y": 33,
+        "w": 4,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "thresholds",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "unhealthy_proxies",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 41,
+      "type": "stat",
+      "title": "Healthy Proxies",
+      "gridPos": {
+        "x": 4,
+        "y": 33,
+        "w": 4,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "thresholds",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "healthy_proxies",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 42,
+      "type": "timeseries",
+      "title": "Proxy Health Over Time",
+      "gridPos": {
+        "x": 0,
+        "y": 37,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Healthy"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Unhealthy"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "healthy_proxies",
+          "legendFormat": "Healthy",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "unhealthy_proxies",
+          "legendFormat": "Unhealthy",
+          "refId": "B"
+        }
+      ],
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 43,
+      "type": "timeseries",
+      "title": "Proxy Health Check Rate",
+      "gridPos": {
+        "x": 8,
+        "y": 37,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pass"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "fail"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(proxy_health_checks_total[5m])",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 44,
+      "type": "timeseries",
+      "title": "Proxy Replacement Outcomes",
+      "gridPos": {
+        "x": 16,
+        "y": 37,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "webshare_api"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool_rotation"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool_sharing"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(proxy_replacements_total[5m])",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "10.0.0"
+    },
+    {
       "id": 18,
       "type": "row",
       "title": "Server Converter",
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 37,
+        "y": 45,
         "w": 24,
         "h": 1
       },
@@ -1048,7 +1445,7 @@
       ],
       "gridPos": {
         "x": 0,
-        "y": 38,
+        "y": 46,
         "w": 8,
         "h": 8
       },
@@ -1109,7 +1506,7 @@
       ],
       "gridPos": {
         "x": 8,
-        "y": 38,
+        "y": 46,
         "w": 8,
         "h": 8
       },
@@ -1149,7 +1546,7 @@
       ],
       "gridPos": {
         "x": 16,
-        "y": 46,
+        "y": 54,
         "w": 8,
         "h": 8
       },
@@ -1194,7 +1591,7 @@
       ],
       "gridPos": {
         "x": 0,
-        "y": 46,
+        "y": 54,
         "w": 8,
         "h": 8
       },
@@ -1239,7 +1636,7 @@
       ],
       "gridPos": {
         "x": 8,
-        "y": 46,
+        "y": 54,
         "w": 8,
         "h": 8
       },
@@ -1279,7 +1676,7 @@
       ],
       "gridPos": {
         "x": 0,
-        "y": 54,
+        "y": 62,
         "w": 8,
         "h": 8
       },
@@ -1319,7 +1716,7 @@
       ],
       "gridPos": {
         "x": 8,
-        "y": 54,
+        "y": 62,
         "w": 8,
         "h": 8
       },
@@ -1364,7 +1761,7 @@
       ],
       "gridPos": {
         "x": 16,
-        "y": 54,
+        "y": 62,
         "w": 8,
         "h": 8
       },
@@ -1404,7 +1801,7 @@
       ],
       "gridPos": {
         "x": 0,
-        "y": 62,
+        "y": 70,
         "w": 8,
         "h": 8
       },
@@ -1463,7 +1860,7 @@
       ],
       "gridPos": {
         "x": 8,
-        "y": 62,
+        "y": 70,
         "w": 8,
         "h": 8
       },
@@ -1519,7 +1916,7 @@
       ],
       "gridPos": {
         "x": 16,
-        "y": 62,
+        "y": 70,
         "w": 8,
         "h": 8
       },
@@ -1539,7 +1936,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 70,
+        "y": 78,
         "w": 24,
         "h": 1
       },
@@ -1559,7 +1956,7 @@
       ],
       "gridPos": {
         "x": 0,
-        "y": 71,
+        "y": 79,
         "w": 12,
         "h": 12
       },
@@ -1586,7 +1983,7 @@
       ],
       "gridPos": {
         "x": 12,
-        "y": 71,
+        "y": 79,
         "w": 12,
         "h": 12
       },
@@ -1606,7 +2003,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 83,
+        "y": 91,
         "w": 24,
         "h": 1
       },
@@ -1626,7 +2023,7 @@
       ],
       "gridPos": {
         "x": 0,
-        "y": 84,
+        "y": 92,
         "w": 8,
         "h": 8
       },
@@ -1687,7 +2084,7 @@
       ],
       "gridPos": {
         "x": 8,
-        "y": 84,
+        "y": 92,
         "w": 8,
         "h": 8
       },
@@ -1748,7 +2145,7 @@
       ],
       "gridPos": {
         "x": 16,
-        "y": 84,
+        "y": 92,
         "w": 8,
         "h": 8
       },

--- a/services/server_observer/config.example.toml
+++ b/services/server_observer/config.example.toml
@@ -32,6 +32,10 @@ port = 6379
 stream_name = "game_responses"
 # password = "optional-redis-password"
 
+[proxy]
+# How often (seconds) to proactively check each account's proxy and replace failing ones.
+health_check_interval_seconds = 120
+
 [storage]
 [storage.s3]
 endpoint_url = "https://your-s3-endpoint.example.com"

--- a/services/server_observer/src/account_pool.rs
+++ b/services/server_observer/src/account_pool.rs
@@ -1,4 +1,5 @@
 use crate::connectivity_check;
+use crate::metrics::{record_proxy_replacement};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -398,6 +399,7 @@ impl AccountPool {
                     if let Some(cb) = &self.proxy_reset_callback {
                         cb(username.to_string());
                     }
+                    record_proxy_replacement("webshare_api");
                     tracing::info!(
                         account = username,
                         old_proxy_id = %old_proxy_id,
@@ -414,7 +416,11 @@ impl AccountPool {
         }
 
         // Fallback: rotate within the existing pool.
-        self.reset_account_proxy(username).await
+        let ok = self.reset_account_proxy(username).await;
+        if !ok {
+            record_proxy_replacement("failed");
+        }
+        ok
     }
 
     /// Replaces a single broken proxy via the WebShare v3 replacement API. That API is
@@ -549,14 +555,34 @@ impl AccountPool {
             .filter(|id| self.proxies.contains_key(id))
             .collect();
 
-        let Some(new_proxy_id) = self
+        // Try to find an unassigned proxy first; fall back to least-shared when pool is exhausted.
+        let (new_proxy_id, shared) = if let Some(id) = self
             .proxies
             .keys()
             .find(|id| !assigned_ids.contains(*id))
             .cloned()
-        else {
-            tracing::error!("no unassigned proxy available for reset");
-            return false;
+        {
+            (id, false)
+        } else {
+            tracing::warn!(
+                account = username,
+                "no unassigned proxy available; sharing least-used proxy"
+            );
+            let best = self
+                .proxies
+                .keys()
+                .min_by_key(|pid| {
+                    self.accounts
+                        .iter()
+                        .filter(|a| &a.proxy_config.proxy_id == *pid)
+                        .count()
+                })
+                .cloned();
+            let Some(id) = best else {
+                tracing::error!("proxy pool is empty; cannot assign any proxy");
+                return false;
+            };
+            (id, true)
         };
 
         let Some(proxy) = self.proxies.get(&new_proxy_id) else {
@@ -573,17 +599,43 @@ impl AccountPool {
             },
         );
 
+        let share_count = if shared {
+            self.accounts
+                .iter()
+                .filter(|a| a.proxy_config.proxy_id == new_proxy_id)
+                .count()
+                + 1
+        } else {
+            1
+        };
+
         let Some(account) = self.accounts.iter_mut().find(|a| a.username == username) else {
             return false;
         };
         account.proxy_config = new_cfg;
 
-        tracing::info!(
-            account = username,
-            old_proxy_id = old_proxy_id,
-            new_proxy_id = new_proxy_id,
-            "successfully reset account proxy"
-        );
+        if shared {
+            tracing::info!(
+                account = username,
+                old_proxy_id = old_proxy_id,
+                new_proxy_id = new_proxy_id,
+                share_count,
+                "reset account proxy (sharing)"
+            );
+            record_proxy_replacement("pool_sharing");
+        } else {
+            tracing::info!(
+                account = username,
+                old_proxy_id = old_proxy_id,
+                new_proxy_id = new_proxy_id,
+                "successfully reset account proxy"
+            );
+            record_proxy_replacement("pool_rotation");
+        }
+
+        if let Err(err) = self.save_to_file() {
+            tracing::warn!(?err, "failed to persist proxy assignment to disk after rotation");
+        }
 
         if let Some(callback) = &self.proxy_reset_callback {
             callback(username.to_string());

--- a/services/server_observer/src/metrics.rs
+++ b/services/server_observer/src/metrics.rs
@@ -195,6 +195,55 @@ static REDIS_PUBLISH_FAILURES_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     counter
 });
 
+// Proxy health metrics
+static PROXY_HEALTH_CHECKS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    let opts = Opts::new(
+        "proxy_health_checks_total",
+        "Outcomes of proactive proxy health checks",
+    );
+    let vec = IntCounterVec::new(opts, &["result"]).expect("create proxy_health_checks_total");
+    default_registry()
+        .register(Box::new(vec.clone()))
+        .expect("register proxy_health_checks_total");
+    vec
+});
+
+static PROXY_REPLACEMENTS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    let opts = Opts::new(
+        "proxy_replacements_total",
+        "Proxy replacement outcomes by method",
+    );
+    let vec = IntCounterVec::new(opts, &["outcome"]).expect("create proxy_replacements_total");
+    default_registry()
+        .register(Box::new(vec.clone()))
+        .expect("register proxy_replacements_total");
+    vec
+});
+
+static HEALTHY_PROXIES: Lazy<IntGauge> = Lazy::new(|| {
+    let opts = Opts::new(
+        "healthy_proxies",
+        "Number of proxies currently passing health checks",
+    );
+    let gauge = IntGauge::with_opts(opts).expect("create healthy_proxies");
+    default_registry()
+        .register(Box::new(gauge.clone()))
+        .expect("register healthy_proxies");
+    gauge
+});
+
+static UNHEALTHY_PROXIES: Lazy<IntGauge> = Lazy::new(|| {
+    let opts = Opts::new(
+        "unhealthy_proxies",
+        "Number of proxies currently failing health checks",
+    );
+    let gauge = IntGauge::with_opts(opts).expect("create unhealthy_proxies");
+    default_registry()
+        .register(Box::new(gauge.clone()))
+        .expect("register unhealthy_proxies");
+    gauge
+});
+
 // Public helpers used by the rest of the crate
 pub fn record_game_started(scenario_id: i32) {
     GAMES_STARTED_TOTAL
@@ -270,6 +319,23 @@ pub fn set_down_server_count(n: i64) {
 
 pub fn record_redis_publish_failure() {
     REDIS_PUBLISH_FAILURES_TOTAL.inc();
+}
+
+pub fn record_proxy_health_check(result: &str) {
+    PROXY_HEALTH_CHECKS_TOTAL
+        .with_label_values(&[result])
+        .inc();
+}
+
+pub fn set_proxy_health_counts(healthy: i64, unhealthy: i64) {
+    HEALTHY_PROXIES.set(healthy);
+    UNHEALTHY_PROXIES.set(unhealthy);
+}
+
+pub fn record_proxy_replacement(outcome: &str) {
+    PROXY_REPLACEMENTS_TOTAL
+        .with_label_values(&[outcome])
+        .inc();
 }
 
 pub struct MetricsServer {

--- a/services/server_observer/src/observation_session.rs
+++ b/services/server_observer/src/observation_session.rs
@@ -130,6 +130,10 @@ pub struct ObservationSession {
     /// Survives `reset_package()` so connectivity checks can use the real game-server address
     /// even after the session package has been cleared on error.
     pub last_game_server_address: String,
+    /// Last raw HTTP response body received from the game server. Updated on every request that
+    /// returns an HTTP 200 body (auth errors, parse errors, success, etc.). Persists across
+    /// resets so the dead letter always has the most recent server response for diagnosis.
+    pub last_raw_response: Option<String>,
 
     map_cache: Option<StaticMapCache>,
     api: Option<ObservationApi>,
@@ -158,6 +162,7 @@ impl ObservationSession {
             next_update_at: SystemTime::now(),
             update_sequence_number: 0,
             last_game_server_address: String::new(),
+            last_raw_response: None,
             map_cache,
             api: None,
             storage_path,
@@ -246,6 +251,7 @@ impl ObservationSession {
         }
 
         self.package = self.create_observation_package()?;
+        self.hub_interface = None;
         Ok(())
     }
 
@@ -490,6 +496,10 @@ impl ObservationSession {
                 &mut self.package.state_ids,
                 &mut self.package.time_stamps,
             );
+
+            if !result.raw_response.is_empty() {
+                self.last_raw_response = Some(result.raw_response.clone());
+            }
 
             if !result.success() {
                 return self.handle_game_server_error(&result);

--- a/services/server_observer/src/server_observer.rs
+++ b/services/server_observer/src/server_observer.rs
@@ -811,6 +811,7 @@ impl ServerObserver {
             };
             record_game_failed(error_type);
 
+            let last_raw_response = session_arc.lock().await.last_raw_response.clone();
             let ts = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
@@ -821,6 +822,7 @@ impl ServerObserver {
                 "error_code": error_type,
                 "error_message": &result.error_message,
                 "account": &username,
+                "last_raw_response": last_raw_response,
             });
             if let Ok(mut f) = std::fs::OpenOptions::new()
                 .create(true)

--- a/services/server_observer/src/server_observer.rs
+++ b/services/server_observer/src/server_observer.rs
@@ -6,6 +6,7 @@ use crate::metrics::{
     record_game_completed, record_game_failed, record_game_started, record_game_resumed, record_game_update_retry,
     record_missed_interval, record_scheduled_update_latency, record_game_update_completed,
     record_game_update_started, set_active_games, set_down_server_count,
+    record_proxy_health_check, set_proxy_health_counts,
 };
 use crate::server_outage_tracker::ServerOutageTracker;
 use crate::observation_session::{ObservationError, ObservationResult, ObservationSession};
@@ -59,6 +60,7 @@ pub struct ServerObserver {
     dead_letter_path: String,
     game_server_status_map: GameServerStatusMap,
     outage_tracker: ServerOutageTracker,
+    proxy_health_check_interval_secs: u64,
 }
 
 impl ServerObserver {
@@ -166,6 +168,10 @@ impl ServerObserver {
             .get::<String>("dead_letter_path")
             .unwrap_or_else(|_| "dead_letter.jsonl".to_string());
 
+        let proxy_health_check_interval_secs = settings
+            .get::<u64>("proxy.health_check_interval_seconds")
+            .unwrap_or(120);
+
         let observer = Arc::new(Self {
             account_pool,
             scheduler,
@@ -190,6 +196,7 @@ impl ServerObserver {
             dead_letter_path,
             game_server_status_map: GameServerStatusMap::new(),
             outage_tracker: ServerOutageTracker::new(),
+            proxy_health_check_interval_secs,
         });
 
         tracing::info!(
@@ -264,6 +271,57 @@ impl ServerObserver {
                             }
                         }
                     }
+                }
+            });
+        }
+
+        // Spawn the proxy health-check probe: periodically checks each account's proxy and
+        // triggers replacement for any that fail, before sessions notice the failure themselves.
+        {
+            let weak = Arc::downgrade(&self);
+            let interval_secs = self.proxy_health_check_interval_secs;
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_secs(interval_secs)).await;
+                    let Some(observer) = weak.upgrade() else { break };
+                    if observer.stop_flag.load(Ordering::SeqCst) { break; }
+
+                    // Snapshot accounts without holding the lock during I/O.
+                    let accounts: Vec<(String, crate::account_pool::ProxyConfig)> = {
+                        let pool = observer.account_pool.lock().await;
+                        pool.accounts.iter()
+                            .filter(|a| a.proxy_config.enabled)
+                            .map(|a| (a.username.clone(), a.proxy_config.clone()))
+                            .collect()
+                    };
+
+                    let mut healthy = 0i64;
+                    let mut unhealthy = 0i64;
+
+                    for (username, proxy_cfg) in accounts {
+                        let proxy_url = proxy_cfg.to_url();
+                        let ok = connectivity_check::proxy_passes_checks(
+                            &proxy_url,
+                            connectivity_check::FALLBACK_GAME_SERVER_URL,
+                        ).await;
+                        if ok {
+                            healthy += 1;
+                            record_proxy_health_check("pass");
+                        } else {
+                            unhealthy += 1;
+                            record_proxy_health_check("fail");
+                            tracing::warn!(
+                                account = %username,
+                                proxy_host = %proxy_cfg.host,
+                                "proactive health check: proxy failed, triggering replacement"
+                            );
+                            let mut pool = observer.account_pool.lock().await;
+                            pool.replace_proxy(&username, connectivity_check::FALLBACK_GAME_SERVER_URL).await;
+                        }
+                    }
+
+                    set_proxy_health_counts(healthy, unhealthy);
+                    tracing::debug!(healthy, unhealthy, "proxy health check sweep complete");
                 }
             });
         }


### PR DESCRIPTION
This pull request introduces proactive proxy health monitoring, improved proxy replacement logic, and enhanced metrics and diagnostics for the `server_observer` service. The main improvements are the addition of a periodic background task that checks proxy health and replaces failing proxies, new Prometheus metrics for proxy health and replacement outcomes, and improved dead-letter logging for better debugging.

**Proxy health monitoring and replacement:**

* Added a background task in `ServerObserver` that periodically checks the health of each account's proxy and proactively replaces any that fail, using the new `proxy.health_check_interval_seconds` config option (`server_observer.rs`, `config.example.toml`). [[1]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR63) [[2]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR171-R174) [[3]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR199) [[4]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR278-R328) [[5]](diffhunk://#diff-6a7e438da614de682e90e150f255d5934da9eff24ec03e12063081cb1cca850aR35-R38)
* Improved proxy replacement logic in `AccountPool`: now tries to assign an unassigned proxy first, and falls back to sharing the least-used proxy if the pool is exhausted. Replacement actions are now logged and tracked with outcome labels (`account_pool.rs`). [[1]](diffhunk://#diff-a2fed9c8d723e13172b33420849396c78ea907a90f84eb49c2b3d084a0dfcca1L552-R586) [[2]](diffhunk://#diff-a2fed9c8d723e13172b33420849396c78ea907a90f84eb49c2b3d084a0dfcca1R602-R638) [[3]](diffhunk://#diff-a2fed9c8d723e13172b33420849396c78ea907a90f84eb49c2b3d084a0dfcca1R402) [[4]](diffhunk://#diff-a2fed9c8d723e13172b33420849396c78ea907a90f84eb49c2b3d084a0dfcca1L417-R423)

**Metrics and observability:**

* Added new Prometheus metrics for proxy health check outcomes, replacement outcomes, and counts of healthy/unhealthy proxies. Metrics are updated during health checks and replacements (`metrics.rs`). [[1]](diffhunk://#diff-871ddee1044afb4f8edb76b6dad7ff4ee717d0fe729797165ef5378a2e452aadR198-R246) [[2]](diffhunk://#diff-871ddee1044afb4f8edb76b6dad7ff4ee717d0fe729797165ef5378a2e452aadR324-R340) [[3]](diffhunk://#diff-a2fed9c8d723e13172b33420849396c78ea907a90f84eb49c2b3d084a0dfcca1R2) [[4]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR9)
* Exposed proxy replacement outcomes via labeled metrics for better observability of pool exhaustion and API failures (`account_pool.rs`, `metrics.rs`). [[1]](diffhunk://#diff-a2fed9c8d723e13172b33420849396c78ea907a90f84eb49c2b3d084a0dfcca1R402) [[2]](diffhunk://#diff-a2fed9c8d723e13172b33420849396c78ea907a90f84eb49c2b3d084a0dfcca1L417-R423) [[3]](diffhunk://#diff-a2fed9c8d723e13172b33420849396c78ea907a90f84eb49c2b3d084a0dfcca1R602-R638)

**Diagnostics and dead-letter logging:**

* `ObservationSession` now tracks the last raw HTTP response from the game server, persisting it across resets. This value is included in dead-letter logs to aid debugging of session failures (`observation_session.rs`, `server_observer.rs`). [[1]](diffhunk://#diff-fae495b197ab18422101d7ca092344b644bf278411cd51fa83d30c7535bea5d8R133-R136) [[2]](diffhunk://#diff-fae495b197ab18422101d7ca092344b644bf278411cd51fa83d30c7535bea5d8R165) [[3]](diffhunk://#diff-fae495b197ab18422101d7ca092344b644bf278411cd51fa83d30c7535bea5d8R500-R503) [[4]](diffhunk://#diff-fae495b197ab18422101d7ca092344b644bf278411cd51fa83d30c7535bea5d8R254) [[5]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR872) [[6]](diffhunk://#diff-1e5d248105de459b162637927df53f5effdce966b0c84a0d83a5850eb77bbe0fR883)

**Configuration and deployment:**

* Added `PYTHONMALLOC=malloc` to relevant Docker Compose services for improved memory diagnostics (`infra/docker-compose.yml`). [[1]](diffhunk://#diff-6636069cba3e1b359b84b30d2c70cbf96e6119237bbc67acc21ec03d1893ab21R107) [[2]](diffhunk://#diff-6636069cba3e1b359b84b30d2c70cbf96e6119237bbc67acc21ec03d1893ab21R162)

These changes make proxy management more robust, observable, and debuggable in production.