### PR TITLE
Fix desktop version.py drift from pyproject.toml

### DIFF
--- a/apps/desktop/src/conlyse/version.py
+++ b/apps/desktop/src/conlyse/version.py
@@ -3,5 +3,5 @@ from __future__ import annotations
 __all__ = ["__version__"]
 
 # Keep this in sync with the version in pyproject.toml.
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 


### PR DESCRIPTION
## Summary
- \`apps/desktop/src/conlyse/version.py\` still said \`0.1.0\` after \`pyproject.toml\` was bumped to \`0.1.1\` in 416695cc. The app reads \`version.py\` at runtime for the update checker, so it was reporting the wrong version.

## Test plan
- [x] One-line string change, no behavior to test beyond visual confirmation the two files now match.