### PR TITLE
Optimize deserialization for primitive types

### DIFF
--- a/libs/conflict_interface/conflict_interface/game_object/game_object_binary.py
+++ b/libs/conflict_interface/conflict_interface/game_object/game_object_binary.py
@@ -160,7 +160,12 @@ class GameObjectSerializer:
 
         if t is dict:
             from_raw = self._from_raw
-            return {from_raw(k): from_raw(v) for k, v in data["__dict__"]}
+            primitives = self._PRIMITIVES
+            return {
+                (k if type(k) in primitives else from_raw(k)):
+                    (v if type(v) in primitives else from_raw(v))
+                for k, v in data["__dict__"]
+            }
 
 
         if t is list:
@@ -170,7 +175,8 @@ class GameObjectSerializer:
             else:
                 # Plain list
                 from_raw = self._from_raw
-                return [from_raw(v) for v in data]
+                primitives = self._PRIMITIVES
+                return [v if type(v) in primitives else from_raw(v) for v in data]
 
         raise TypeError(f"Cannot deserialize:  {type(data)} \n {str(data)[:1000]}")
 
@@ -187,19 +193,29 @@ class GameObjectSerializer:
             )
         cat = self._category[cls]
         from_raw = self._from_raw
+        # Avoid a full recursive _from_raw call (frame setup + branch tree)
+        # for the common case of an already-primitive field value.
+        primitives = self._PRIMITIVES
 
         if cat in (SerializationCategory.DATACLASS, SerializationCategory.GAME_STATE, SerializationCategory.STATIC_MAP_DATA):
             field_names = self._fields[cls]
-            kwargs = {name: from_raw(data[i + 2]) for i, name in enumerate(field_names)}
+            kwargs = {}
+            for i, name in enumerate(field_names):
+                v = data[i + 2]
+                kwargs[name] = v if type(v) in primitives else from_raw(v)
             instance = cls(**kwargs)
             instance.game = None
             return instance
 
         elif cat == SerializationCategory.LIST:
-            return cls([from_raw(v) for v in data[2]])
+            return cls([v if type(v) in primitives else from_raw(v) for v in data[2]])
 
         elif cat == SerializationCategory.DICT:
-            return cls({from_raw(pair[0]): from_raw(pair[1]) for pair in data[2]})
+            return cls({
+                (pair[0] if type(pair[0]) in primitives else from_raw(pair[0])):
+                    (pair[1] if type(pair[1]) in primitives else from_raw(pair[1]))
+                for pair in data[2]
+            })
 
         elif cat == SerializationCategory.DATETIME:
             return cls.fromtimestamp(data[2], UTC)


### PR DESCRIPTION
This pull request optimizes the deserialization logic in `game_object_binary.py` by avoiding unnecessary recursive calls to `_from_raw` for primitive types. Instead, it directly returns primitive values, improving performance and reducing call stack overhead. The main changes focus on handling lists, dictionaries, and class fields during deserialization.

**Deserialization performance improvements:**

* Updated the dictionary deserialization logic in `_from_raw` to check if keys or values are primitive types using `_PRIMITIVES` and avoid recursive calls for those cases.
* Updated the list deserialization logic in `_from_raw` to check each element's type and skip recursion for primitives.
* In `_from_raw_registered`, optimized the handling of dataclass fields, lists, and dictionaries by directly assigning primitive values and only calling `_from_raw` for non-primitives, reducing unnecessary recursion.…primitive types