### PR TITLE
Enhance game aggregates with statistics, tracking, and optimizations

### DIFF
--- a/apps/docs/src/components/statistics/StatsSidebar.tsx
+++ b/apps/docs/src/components/statistics/StatsSidebar.tsx
@@ -19,6 +19,7 @@ const SECTIONS: SidebarSection[] = [
     items: [
       { id: 'chart-global-duration',  label: 'Game Duration' },
       { id: 'chart-global-victory',   label: 'Victory Types' },
+      { id: 'chart-global-traitors',  label: 'Traitor Wins' },
       { id: 'chart-global-dropout',   label: 'Player Dropout' },
       { id: 'chart-global-diplomacy', label: 'Diplomacy' },
       { id: 'chart-global-activity',  label: 'Player Activity' },

--- a/apps/docs/src/components/statistics/charts/CoalitionSizeDistributionChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CoalitionSizeDistributionChart.tsx
@@ -45,8 +45,8 @@ export default function CoalitionSizeDistributionChart({ data }: Props) {
             borderRadius: 6,
             color: 'var(--ifm-font-color-base)',
           }}
-          formatter={(value: number, _: string, props) => [
-            `${value} games (${props.payload.pct}%)`,
+          formatter={(_: number, __: string, props) => [
+            `${props.payload.pct}%`,
             'Games',
           ]}
         />

--- a/apps/docs/src/components/statistics/charts/CoalitionWinRateChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CoalitionWinRateChart.tsx
@@ -27,7 +27,6 @@ export default function CoalitionWinRateChart({ data, topN = 20 }: Props) {
       coalition_pct: parseFloat((((c.coalition_wins ?? 0) / c.games_played) * 100).toFixed(1)),
       solo_wins: c.solo_wins ?? 0,
       coalition_wins: c.coalition_wins ?? 0,
-      games: c.games_played,
     }));
 
   if (chartData.length === 0) return <p style={{ color: 'var(--ifm-color-emphasis-500)', fontSize: 13 }}>No coalition data available yet.</p>;
@@ -62,7 +61,7 @@ export default function CoalitionWinRateChart({ data, topN = 20 }: Props) {
           formatter={(value: number, name: string, props) => {
             const label = name === 'solo_pct' ? 'Solo wins' : 'Coalition wins';
             const count = name === 'solo_pct' ? props.payload.solo_wins : props.payload.coalition_wins;
-            return [`${value}% (${count} wins of ${props.payload.games} games)`, label];
+            return [`${value}% (${count} wins)`, label];
           }}
         />
         <Legend

--- a/apps/docs/src/components/statistics/charts/CountryAggressivenessChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryAggressivenessChart.tsx
@@ -27,7 +27,6 @@ export default function CountryAggressivenessChart({ data, topN = 20, minGames =
       captured: parseFloat(c.avg_provinces_captured.toFixed(1)),
       lost: parseFloat(c.avg_provinces_lost.toFixed(1)),
       net: parseFloat((c.avg_provinces_captured - c.avg_provinces_lost).toFixed(1)),
-      games: c.games_played,
     }));
 
   return (
@@ -57,9 +56,9 @@ export default function CountryAggressivenessChart({ data, topN = 20, minGames =
             color: 'var(--ifm-font-color-base)',
           }}
           formatter={(value: number, name: string, props) => {
-            const { net, games } = props.payload;
+            const { net } = props.payload;
             const sign = net >= 0 ? '+' : '';
-            return [`${value} avg · net ${sign}${net} · ${games} games`, name];
+            return [`${value} avg · net ${sign}${net}`, name];
           }}
         />
         <Legend wrapperStyle={{ fontSize: 11 }} />

--- a/apps/docs/src/components/statistics/charts/CountryDiplomacyChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryDiplomacyChart.tsx
@@ -25,7 +25,6 @@ export default function CountryDiplomacyChart({ data, topN = 20, minGames = 3 }:
       wars: parseFloat(c.avg_wars_declared.toFixed(1)),
       rows: parseFloat(c.avg_right_of_ways_signed.toFixed(1)),
       peace: parseFloat(c.avg_peace_treaties_signed.toFixed(1)),
-      games: c.games_played,
     }))
     .sort((a, b) => (b.wars + b.rows + b.peace) - (a.wars + a.rows + a.peace))
     .slice(0, topN);
@@ -57,9 +56,9 @@ export default function CountryDiplomacyChart({ data, topN = 20, minGames = 3 }:
             color: 'var(--ifm-font-color-base)',
           }}
           formatter={(value: number, name: string, props) => {
-            const { wars, rows, peace, games } = props.payload;
+            const { wars, rows, peace } = props.payload;
             return [
-              `${value} avg · total ${(wars + rows + peace).toFixed(1)} diplomatic acts · ${games} games`,
+              `${value} avg · total ${(wars + rows + peace).toFixed(1)} diplomatic acts`,
               name,
             ];
           }}

--- a/apps/docs/src/components/statistics/charts/CountryEliminationChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryEliminationChart.tsx
@@ -24,7 +24,6 @@ export default function CountryEliminationChart({ data, topN = 20 }: Props) {
       name: c.nation_name,
       elimination_rate: parseFloat((c.elimination_rate * 100).toFixed(1)),
       survival_days: parseFloat(c.avg_survival_days.toFixed(1)),
-      games: c.games_played,
     }));
 
   return (
@@ -55,7 +54,7 @@ export default function CountryEliminationChart({ data, topN = 20 }: Props) {
             color: 'var(--ifm-font-color-base)',
           }}
           formatter={(value: number, _: string, props) => [
-            `${value}% eliminated · ${props.payload.survival_days}d avg survival · ${props.payload.games} games`,
+            `${value}% eliminated · ${props.payload.survival_days}d avg survival`,
             'Elimination rate',
           ]}
         />

--- a/apps/docs/src/components/statistics/charts/CountryEliminationTimingChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryEliminationTimingChart.tsx
@@ -25,7 +25,6 @@ export default function CountryEliminationTimingChart({ data, topN = 20 }: Props
       name: c.nation_name,
       avg_elim_pct: parseFloat((c.avg_elimination_pct ?? 0).toFixed(1)),
       elim_rate: parseFloat((c.elimination_rate * 100).toFixed(1)),
-      games: c.games_played,
     }));
 
   if (chartData.length === 0) return <p style={{ color: 'var(--ifm-color-emphasis-500)', fontSize: 13 }}>No elimination timing data available yet.</p>;
@@ -58,7 +57,7 @@ export default function CountryEliminationTimingChart({ data, topN = 20 }: Props
             color: 'var(--ifm-font-color-base)',
           }}
           formatter={(value: number, _: string, props) => [
-            `Eliminated at ${value}% of game · ${props.payload.elim_rate}% elim rate · ${props.payload.games} games`,
+            `Eliminated at ${value}% of game · ${props.payload.elim_rate}% elim rate`,
             'Avg elimination point',
           ]}
         />

--- a/apps/docs/src/components/statistics/charts/CountryExpansionChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryExpansionChart.tsx
@@ -25,7 +25,6 @@ export default function CountryExpansionChart({ data, topN = 20 }: Props) {
       expansion: parseFloat(c.avg_expansion.toFixed(1)),
       initial: parseFloat(c.avg_initial_provinces.toFixed(1)),
       final: parseFloat(c.avg_final_provinces.toFixed(1)),
-      games: c.games_played,
     }));
 
   return (
@@ -55,7 +54,7 @@ export default function CountryExpansionChart({ data, topN = 20 }: Props) {
             color: 'var(--ifm-font-color-base)',
           }}
           formatter={(value: number, _: string, props) => [
-            `${value > 0 ? '+' : ''}${value} provinces (${props.payload.initial} → ${props.payload.final}) · ${props.payload.games} games`,
+            `${value > 0 ? '+' : ''}${value} provinces (${props.payload.initial} → ${props.payload.final})`,
             'Avg expansion',
           ]}
         />

--- a/apps/docs/src/components/statistics/charts/CountryMoraleChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryMoraleChart.tsx
@@ -25,7 +25,6 @@ export default function CountryMoraleChart({ data, topN = 20 }: Props) {
       name: c.nation_name,
       morale: parseFloat((c.avg_national_morale ?? 0).toFixed(1)),
       win_rate: parseFloat((c.win_rate * 100).toFixed(1)),
-      games: c.games_played,
     }));
 
   if (chartData.length === 0) return <p style={{ color: 'var(--ifm-color-emphasis-500)', fontSize: 13 }}>No morale data available yet.</p>;
@@ -58,7 +57,7 @@ export default function CountryMoraleChart({ data, topN = 20 }: Props) {
             color: 'var(--ifm-font-color-base)',
           }}
           formatter={(value: number, _: string, props) => [
-            `${value}% morale · ${props.payload.win_rate}% win rate · ${props.payload.games} games`,
+            `${value}% morale · ${props.payload.win_rate}% win rate`,
             'Avg national morale',
           ]}
         />

--- a/apps/docs/src/components/statistics/charts/CountryPlacementChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryPlacementChart.tsx
@@ -24,7 +24,6 @@ export default function CountryPlacementChart({ data, topN = 20 }: Props) {
       name: c.nation_name,
       placement: parseFloat(c.avg_placement.toFixed(2)),
       vp: Math.round(c.avg_final_vp),
-      games: c.games_played,
     }));
 
   return (
@@ -54,7 +53,7 @@ export default function CountryPlacementChart({ data, topN = 20 }: Props) {
             color: 'var(--ifm-font-color-base)',
           }}
           formatter={(value: number, _: string, props) => [
-            `#${value} avg rank · ${props.payload.vp} avg VP · ${props.payload.games} games`,
+            `#${value} avg rank · ${props.payload.vp} avg VP`,
             'Placement',
           ]}
         />

--- a/apps/docs/src/components/statistics/charts/CountrySimilarityScatterChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountrySimilarityScatterChart.tsx
@@ -1,0 +1,114 @@
+import React, { useMemo } from 'react';
+import {
+  CartesianGrid,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { ClusterInfo, NationSimilarityAggregate } from '../types';
+
+interface Props {
+  data: NationSimilarityAggregate[];
+  clusters: ClusterInfo[];
+}
+
+const CLUSTER_COLORS = [
+  '#4e79a7', '#f28e2b', '#e15759', '#76b7b2', '#59a14f',
+  '#edc948', '#b07aa1', '#ff9da7', '#9c755f', '#bab0ac',
+];
+
+function colorForCluster(clusterId: number): string {
+  return CLUSTER_COLORS[clusterId % CLUSTER_COLORS.length];
+}
+
+interface ScatterPoint {
+  name: string;
+  x: number;
+  y: number;
+  humanGames: number;
+  topBuildings: string[];
+  fill: string;
+}
+
+function CustomDot(props: { cx?: number; cy?: number; payload?: ScatterPoint }) {
+  const { cx = 0, cy = 0, payload } = props;
+  if (!payload) return null;
+  return <circle cx={cx} cy={cy} r={5} fill={payload.fill} fillOpacity={0.8} />;
+}
+
+function CustomTooltip({ active, payload }: { active?: boolean; payload?: { payload: ScatterPoint }[] }) {
+  if (!active || !payload?.length) return null;
+  const p = payload[0].payload;
+  return (
+    <div style={{
+      background: 'var(--ifm-background-surface-color)',
+      border: '1px solid var(--ifm-color-emphasis-300)',
+      borderRadius: 6,
+      padding: '6px 10px',
+      fontSize: 12,
+      color: 'var(--ifm-font-color-base)',
+      lineHeight: 1.6,
+    }}>
+      <div style={{ fontWeight: 600 }}>{p.name}</div>
+      <div>{p.humanGames} human games sampled</div>
+      <div>Distinctive builds: {p.topBuildings.join(', ')}</div>
+    </div>
+  );
+}
+
+function ClusterLegend({ clusters }: { clusters: ClusterInfo[] }) {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 14px', marginTop: 10, fontSize: 11, color: 'var(--ifm-font-color-base)' }}>
+      {clusters.map((c) => (
+        <span key={c.id} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <span style={{ width: 8, height: 8, borderRadius: '50%', background: colorForCluster(c.id), display: 'inline-block' }} />
+          {c.label} ({c.size})
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function CountrySimilarityScatterChart({ data, clusters }: Props) {
+  const points = useMemo<ScatterPoint[]>(
+    () => data.map((n) => ({
+      name: n.nation_name,
+      x: n.pca_x,
+      y: n.pca_y,
+      humanGames: n.human_games_played,
+      topBuildings: n.top_buildings,
+      fill: colorForCluster(n.cluster_id),
+    })),
+    [data],
+  );
+
+  if (points.length === 0) return null;
+
+  return (
+    <div>
+      <ResponsiveContainer width="100%" height={480}>
+        <ScatterChart margin={{ top: 24, right: 24, left: 8, bottom: 24 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--ifm-color-emphasis-200)" />
+          <XAxis
+            type="number"
+            dataKey="x"
+            tick={false}
+            label={{ value: 'Build style (PC1) — proximity = similarity', position: 'insideBottom', offset: -14, fontSize: 11, fill: 'var(--ifm-color-emphasis-500)' }}
+          />
+          <YAxis
+            type="number"
+            dataKey="y"
+            tick={false}
+            label={{ value: 'Build style (PC2)', angle: -90, position: 'insideLeft', offset: 14, fontSize: 11, fill: 'var(--ifm-color-emphasis-500)' }}
+          />
+          <Tooltip content={<CustomTooltip />} />
+          <Scatter data={points} shape={CustomDot} />
+        </ScatterChart>
+      </ResponsiveContainer>
+      <ClusterLegend clusters={clusters} />
+    </div>
+  );
+}

--- a/apps/docs/src/components/statistics/charts/CountryWinRateChart.tsx
+++ b/apps/docs/src/components/statistics/charts/CountryWinRateChart.tsx
@@ -10,6 +10,7 @@ import {
   YAxis,
 } from 'recharts';
 import type { CountryAggregate } from '../types';
+import { percentileRank, percentileToColor } from '../colorScale';
 
 interface Props {
   data: CountryAggregate[];
@@ -17,12 +18,14 @@ interface Props {
 }
 
 export default function CountryWinRateChart({ data, topN = 20 }: Props) {
+  const allWinRates = data.map((c) => c.win_rate);
   const chartData = data
     .sort((a, b) => b.win_rate - a.win_rate)
     .slice(0, topN)
     .map((c) => ({
       name: c.nation_name,
       win_rate: parseFloat((c.win_rate * 100).toFixed(1)),
+      percentile: percentileRank(c.win_rate, allWinRates),
     }));
 
   return (
@@ -56,10 +59,7 @@ export default function CountryWinRateChart({ data, topN = 20 }: Props) {
         />
         <Bar dataKey="win_rate" radius={[0, 3, 3, 0]}>
           {chartData.map((entry, index) => (
-            <Cell
-              key={`cell-${index}`}
-              fill={entry.win_rate >= 50 ? '#50c878' : entry.win_rate >= 25 ? '#f5a623' : '#e74c3c'}
-            />
+            <Cell key={`cell-${index}`} fill={percentileToColor(entry.percentile)} />
           ))}
         </Bar>
       </BarChart>

--- a/apps/docs/src/components/statistics/charts/EliminationTimingDistributionChart.tsx
+++ b/apps/docs/src/components/statistics/charts/EliminationTimingDistributionChart.tsx
@@ -15,20 +15,23 @@ interface Props {
   data: GlobalAggregate;
 }
 
-const LABELS: Record<string, string> = {
-  '0': '0–10%', '10': '10–20%', '20': '20–30%', '30': '30–40%', '40': '40–50%',
-  '50': '50–60%', '60': '60–70%', '70': '70–80%', '80': '80–90%', '90': '90–100%',
-};
-
 export default function EliminationTimingDistributionChart({ data }: Props) {
   const dist = data.elimination_timing_distribution ?? {};
   if (Object.keys(dist).length === 0) return <p style={{ color: 'var(--ifm-color-emphasis-500)', fontSize: 13 }}>No elimination timing data available yet.</p>;
 
-  const chartData = ['0', '10', '20', '30', '40', '50', '60', '70', '80', '90']
-    .map((b) => ({ label: LABELS[b], bucket: parseInt(b), count: dist[b] ?? 0 }))
-    .filter((d) => d.count > 0);
+  const total = Object.values(dist).reduce((s, v) => s + v, 0);
 
-  const max = Math.max(...chartData.map((d) => d.count));
+  const chartData = Object.keys(dist)
+    .map((b) => parseInt(b))
+    .sort((a, b) => a - b)
+    .map((bucket) => ({
+      label: `Day ${bucket}–${bucket + 10}`,
+      bucket,
+      pct: total > 0 ? ((dist[String(bucket)] ?? 0) / total) * 100 : 0,
+    }))
+    .filter((d) => d.pct > 0);
+
+  const max = Math.max(...chartData.map((d) => d.pct));
 
   return (
     <ResponsiveContainer width="100%" height={260}>
@@ -41,7 +44,7 @@ export default function EliminationTimingDistributionChart({ data }: Props) {
           textAnchor="end"
           interval={0}
         />
-        <YAxis tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }} />
+        <YAxis tickFormatter={(v) => `${v}%`} tick={{ fontSize: 11, fill: 'var(--ifm-font-color-base)' }} />
         <Tooltip
           contentStyle={{
             background: 'var(--ifm-background-surface-color)',
@@ -49,14 +52,14 @@ export default function EliminationTimingDistributionChart({ data }: Props) {
             borderRadius: 6,
             color: 'var(--ifm-font-color-base)',
           }}
-          formatter={(value: number) => [value, 'Eliminations']}
+          formatter={(value: number) => [`${value.toFixed(1)}%`, 'Eliminations']}
         />
-        <Bar dataKey="count" radius={[3, 3, 0, 0]}>
+        <Bar dataKey="pct" radius={[3, 3, 0, 0]}>
           {chartData.map((entry, index) => (
             <Cell
               key={`cell-${index}`}
-              fill={entry.count === max ? '#e74c3c' : '#4a90e2'}
-              fillOpacity={0.85 + (entry.count / max) * 0.15}
+              fill={entry.pct === max ? '#e74c3c' : '#4a90e2'}
+              fillOpacity={0.85 + (entry.pct / max) * 0.15}
             />
           ))}
         </Bar>

--- a/apps/docs/src/components/statistics/charts/PlayerActivityTimeSeriesChart.tsx
+++ b/apps/docs/src/components/statistics/charts/PlayerActivityTimeSeriesChart.tsx
@@ -35,7 +35,6 @@ export default function PlayerActivityTimeSeriesChart({ data }: Props) {
     active_human: p.avg_active_human,
     passive_human: p.avg_passive_human,
     ai: p.avg_ai,
-    n: p.games_sampled,
   }));
 
   const xInterval = mode === 'pct' ? 3 : Math.max(1, Math.floor(data.max_game_days / 10));
@@ -104,11 +103,7 @@ export default function PlayerActivityTimeSeriesChart({ data }: Props) {
               const line = LINES.find((l) => l.key === name);
               return [value.toFixed(1), line?.label ?? name];
             }}
-            labelFormatter={(label, payload) => {
-              const n = payload?.[0]?.payload?.n ?? 0;
-              const pos = mode === 'pct' ? `${label}% of game` : `Day ${label}`;
-              return `${pos} · ${n} games`;
-            }}
+            labelFormatter={(label) => (mode === 'pct' ? `${label}% of game` : `Day ${label}`)}
           />
           <Legend
             wrapperStyle={{ fontSize: 11 }}

--- a/apps/docs/src/components/statistics/charts/ProvinceMoraleChart.tsx
+++ b/apps/docs/src/components/statistics/charts/ProvinceMoraleChart.tsx
@@ -40,7 +40,6 @@ export default function ProvinceMoraleChart({ data, topN = 20 }: Props) {
       name: p.province_name,
       morale: parseFloat(p.avg_morale.toFixed(1)),
       terrain: p.terrain_type,
-      games: p.games_appeared,
       coastal: p.is_coastal,
     }));
 
@@ -72,10 +71,10 @@ export default function ProvinceMoraleChart({ data, topN = 20 }: Props) {
             color: 'var(--ifm-font-color-base)',
           }}
           formatter={(value: number, _: string, props) => {
-            const { terrain, games, coastal } = props.payload;
+            const { terrain, coastal } = props.payload;
             const coastalLabel = coastal ? ' · coastal' : '';
             return [
-              `${value}% avg morale · ${terrain}${coastalLabel} · ${games} games`,
+              `${value}% avg morale · ${terrain}${coastalLabel}`,
               'Avg morale',
             ];
           }}

--- a/apps/docs/src/components/statistics/charts/ProvinceStrategicScatterChart.tsx
+++ b/apps/docs/src/components/statistics/charts/ProvinceStrategicScatterChart.tsx
@@ -16,17 +16,29 @@ interface Props {
   data: ProvinceAggregate[];
 }
 
-const TERRAIN_COLOURS: Record<string, string> = {
-  PLAINS:   '#7bc67a',
-  HILLS:    '#b8a05a',
-  MOUNTAIN: '#8c9db5',
-  FOREST:   '#3a8a4a',
-  URBAN:    '#5b7ec9',
-  JUNGLE:   '#2e7d52',
-  TUNDRA:   '#8ecae6',
-  DESERT:   '#e9c46a',
-  SUBURBAN: '#9b72cf',
+const REGION_COLOURS: Record<string, string> = {
+  EUROPA:        '#2a78d6',
+  ASIA:          '#1baf7a',
+  AFRICA:        '#eda100',
+  NORTH_AMERICA: '#008300',
+  SOUTH_AMERICA: '#4a3aa7',
+  OCEANIA:       '#e34948',
+  NONE:          '#9a9a9a',
 };
+
+const REGION_LABELS: Record<string, string> = {
+  EUROPA:        'Europe',
+  ASIA:          'Asia',
+  AFRICA:        'Africa',
+  NORTH_AMERICA: 'North America',
+  SOUTH_AMERICA: 'South America',
+  OCEANIA:       'Oceania',
+  NONE:          'Unknown',
+};
+
+function formatRegion(region: string): string {
+  return REGION_LABELS[region] ?? region;
+}
 
 const QUADRANT_STYLE = {
   fontSize: 10,
@@ -36,7 +48,7 @@ const QUADRANT_STYLE = {
 
 interface ScatterPoint {
   name: string;
-  terrain: string;
+  region: string;
   changes: number;
   winCorr: number;
   fill: string;
@@ -108,20 +120,20 @@ function CustomTooltip({ active, payload }: { active?: boolean; payload?: { payl
       lineHeight: 1.6,
     }}>
       <div style={{ fontWeight: 600 }}>{p.name}</div>
-      <div>{p.terrain.charAt(0) + p.terrain.slice(1).toLowerCase()}</div>
+      <div>{formatRegion(p.region)}</div>
       <div>Avg ownership changes: {p.changes.toFixed(2)}</div>
       <div>Winner held in {p.winCorr.toFixed(1)}% of games</div>
     </div>
   );
 }
 
-function TerrainLegend({ terrains }: { terrains: string[] }) {
+function RegionLegend({ regions }: { regions: string[] }) {
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 14px', marginTop: 10, fontSize: 11, color: 'var(--ifm-font-color-base)' }}>
-      {terrains.map((t) => (
-        <span key={t} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-          <span style={{ width: 8, height: 8, borderRadius: '50%', background: TERRAIN_COLOURS[t] ?? '#aaa', display: 'inline-block' }} />
-          {t.charAt(0) + t.slice(1).toLowerCase()}
+      {regions.map((r) => (
+        <span key={r} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <span style={{ width: 8, height: 8, borderRadius: '50%', background: REGION_COLOURS[r] ?? '#aaa', display: 'inline-block' }} />
+          {formatRegion(r)}
         </span>
       ))}
     </div>
@@ -132,10 +144,10 @@ export default function ProvinceStrategicScatterChart({ data }: Props) {
   const points = useMemo<ScatterPoint[]>(
     () => data.map((p) => ({
       name: p.province_name,
-      terrain: p.terrain_type,
+      region: p.region,
       changes: parseFloat(p.avg_ownership_changes.toFixed(2)),
       winCorr: parseFloat((p.win_correlation * 100).toFixed(2)),
-      fill: TERRAIN_COLOURS[p.terrain_type] ?? '#aaaaaa',
+      fill: REGION_COLOURS[p.region] ?? '#aaaaaa',
     })),
     [data],
   );
@@ -154,7 +166,7 @@ export default function ProvinceStrategicScatterChart({ data }: Props) {
   }, [points]);
 
   const outlierSet = useMemo(() => buildOutlierSet(points), [points]);
-  const terrains = useMemo(() => [...new Set(points.map((p) => p.terrain))].sort(), [points]);
+  const regions = useMemo(() => [...new Set(points.map((p) => p.region))].sort(), [points]);
   const CustomDot = useMemo(() => makeDotRenderer(outlierSet, medChanges, medWinCorr), [outlierSet, medChanges, medWinCorr]);
 
   return (
@@ -194,7 +206,7 @@ export default function ProvinceStrategicScatterChart({ data }: Props) {
           <Scatter data={points} shape={CustomDot} />
         </ScatterChart>
       </ResponsiveContainer>
-      <TerrainLegend terrains={terrains} />
+      <RegionLegend regions={regions} />
     </div>
   );
 }

--- a/apps/docs/src/components/statistics/charts/ProvinceStrategicScatterChart.tsx
+++ b/apps/docs/src/components/statistics/charts/ProvinceStrategicScatterChart.tsx
@@ -49,61 +49,22 @@ const QUADRANT_STYLE = {
 interface ScatterPoint {
   name: string;
   region: string;
+  originalOwner: string | null;
   changes: number;
   winCorr: number;
   fill: string;
 }
-
-const OUTLIER_N = 10;
 
 function median(sorted: number[]): number {
   const mid = Math.floor(sorted.length / 2);
   return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
 }
 
-function buildOutlierSet(points: ScatterPoint[]): Set<string> {
-  const top = (sorted: ScatterPoint[]) => sorted.slice(0, OUTLIER_N).map((p) => p.name);
-  return new Set([
-    ...top([...points].sort((a, b) => b.winCorr - a.winCorr)),
-    ...top([...points].sort((a, b) => b.changes - a.changes)),
-    ...top([...points].sort((a, b) => (b.changes * b.winCorr) - (a.changes * a.winCorr))),
-  ]);
-}
+function CustomDot(props: { cx?: number; cy?: number; payload?: ScatterPoint }) {
+  const { cx = 0, cy = 0, payload } = props;
+  if (!payload) return null;
 
-function makeDotRenderer(outliers: Set<string>, medChanges: number, medWinCorr: number) {
-  return function CustomDot(props: { cx?: number; cy?: number; payload?: ScatterPoint }) {
-    const { cx = 0, cy = 0, payload } = props;
-    if (!payload) return null;
-    const isOutlier = outliers.has(payload.name);
-
-    const labelRight = payload.changes > medChanges;
-    const labelAbove = payload.winCorr < medWinCorr;
-    const lx = labelRight ? cx - 6 : cx + 6;
-    const ly = labelAbove ? cy + 11 : cy - 5;
-
-    return (
-      <g>
-        <circle
-          cx={cx}
-          cy={cy}
-          r={isOutlier ? 5 : 3}
-          fill={payload.fill}
-          fillOpacity={isOutlier ? 0.9 : 0.35}
-        />
-        {isOutlier && (
-          <text
-            x={lx}
-            y={ly}
-            fontSize={9}
-            fill="var(--ifm-font-color-base)"
-            textAnchor={labelRight ? 'end' : 'start'}
-          >
-            {payload.name}
-          </text>
-        )}
-      </g>
-    );
-  };
+  return <circle cx={cx} cy={cy} r={4} fill={payload.fill} fillOpacity={0.7} />;
 }
 
 function CustomTooltip({ active, payload }: { active?: boolean; payload?: { payload: ScatterPoint }[] }) {
@@ -121,6 +82,7 @@ function CustomTooltip({ active, payload }: { active?: boolean; payload?: { payl
     }}>
       <div style={{ fontWeight: 600 }}>{p.name}</div>
       <div>{formatRegion(p.region)}</div>
+      {p.originalOwner && <div>Original owner: {p.originalOwner}</div>}
       <div>Avg ownership changes: {p.changes.toFixed(2)}</div>
       <div>Winner held in {p.winCorr.toFixed(1)}% of games</div>
     </div>
@@ -145,6 +107,7 @@ export default function ProvinceStrategicScatterChart({ data }: Props) {
     () => data.map((p) => ({
       name: p.province_name,
       region: p.region,
+      originalOwner: p.original_owner_nation,
       changes: parseFloat(p.avg_ownership_changes.toFixed(2)),
       winCorr: parseFloat((p.win_correlation * 100).toFixed(2)),
       fill: REGION_COLOURS[p.region] ?? '#aaaaaa',
@@ -165,9 +128,7 @@ export default function ProvinceStrategicScatterChart({ data }: Props) {
     };
   }, [points]);
 
-  const outlierSet = useMemo(() => buildOutlierSet(points), [points]);
   const regions = useMemo(() => [...new Set(points.map((p) => p.region))].sort(), [points]);
-  const CustomDot = useMemo(() => makeDotRenderer(outlierSet, medChanges, medWinCorr), [outlierSet, medChanges, medWinCorr]);
 
   return (
     <div>

--- a/apps/docs/src/components/statistics/charts/ProvinceWinCorrelationChart.tsx
+++ b/apps/docs/src/components/statistics/charts/ProvinceWinCorrelationChart.tsx
@@ -23,7 +23,6 @@ export default function ProvinceWinCorrelationChart({ data, topN = 25 }: Props) 
     .map((p) => ({
       name: p.province_name,
       win_pct: parseFloat((p.win_correlation * 100).toFixed(1)),
-      games: p.games_appeared,
     }));
 
   return (
@@ -53,10 +52,7 @@ export default function ProvinceWinCorrelationChart({ data, topN = 25 }: Props) 
             borderRadius: 6,
             color: 'var(--ifm-font-color-base)',
           }}
-          formatter={(value: number, _: string, props) => [
-            `${value}% (${props.payload.games} games)`,
-            'Winner controlled',
-          ]}
+          formatter={(value: number) => [`${value}%`, 'Winner controlled']}
         />
         <Bar dataKey="win_pct" radius={[0, 3, 3, 0]}>
           {chartData.map((entry, index) => (

--- a/apps/docs/src/components/statistics/charts/VictoryTypeChart.tsx
+++ b/apps/docs/src/components/statistics/charts/VictoryTypeChart.tsx
@@ -3,22 +3,35 @@ import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recha
 
 interface Props {
   data: Record<string, number>;
+  totalTraitorWins?: number;
 }
 
-const COLORS = ['#4a90e2', '#50c878', '#f5a623', '#e74c3c'];
-
-const LABELS: Record<string, string> = {
-  solo: 'Solo Victory',
-  coalition: 'Coalition Victory',
-  unknown: 'Unknown',
+const SLICE_META: Record<string, { label: string; color: string }> = {
+  solo: { label: 'Solo Victory (Loyal)', color: '#4a90e2' },
+  solo_traitor: { label: 'Solo Victory (Traitor)', color: '#e74c3c' },
+  coalition: { label: 'Coalition Victory', color: '#50c878' },
+  unknown: { label: 'Unknown', color: '#f5a623' },
 };
 
-export default function VictoryTypeChart({ data }: Props) {
+export default function VictoryTypeChart({ data, totalTraitorWins }: Props) {
   const chartData = Object.entries(data)
     .filter(([, v]) => v > 0)
-    .map(([key, value]) => ({
-      name: LABELS[key] ?? key,
+    .flatMap(([key, value]) => {
+      if (key === 'solo' && totalTraitorWins) {
+        const traitor = Math.min(totalTraitorWins, value);
+        const loyal = value - traitor;
+        return [
+          loyal > 0 ? { key: 'solo', value: loyal } : null,
+          traitor > 0 ? { key: 'solo_traitor', value: traitor } : null,
+        ].filter((d): d is { key: string; value: number } => d !== null);
+      }
+      return [{ key, value }];
+    })
+    .map(({ key, value }) => ({
+      key,
+      name: SLICE_META[key]?.label ?? key,
       value,
+      color: SLICE_META[key]?.color ?? '#999999',
     }));
 
   return (
@@ -32,8 +45,8 @@ export default function VictoryTypeChart({ data }: Props) {
           outerRadius={90}
           dataKey="value"
         >
-          {chartData.map((_, index) => (
-            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+          {chartData.map((d) => (
+            <Cell key={`cell-${d.key}`} fill={d.color} />
           ))}
         </Pie>
         <Tooltip
@@ -45,7 +58,7 @@ export default function VictoryTypeChart({ data }: Props) {
           }}
           formatter={(value: number, name: string) => {
             const total = chartData.reduce((s, d) => s + d.value, 0);
-            return [`${value} games (${((value / total) * 100).toFixed(1)}%)`, name];
+            return [`${((value / total) * 100).toFixed(1)}%`, name];
           }}
         />
         <Legend wrapperStyle={{ fontSize: 12, color: 'var(--ifm-font-color-base)' }} />

--- a/apps/docs/src/components/statistics/colorScale.ts
+++ b/apps/docs/src/components/statistics/colorScale.ts
@@ -1,0 +1,35 @@
+/** Shared percentile-based color scale for statistics charts. */
+
+const CRITICAL: [number, number, number] = [0xe7, 0x4c, 0x3c];
+const WARNING: [number, number, number] = [0xf5, 0xa6, 0x23];
+const GOOD: [number, number, number] = [0x50, 0xc8, 0x78];
+
+/** Percentile rank (0-100) of `value` within `values`, using mid-rank for ties. */
+export function percentileRank(value: number, values: number[]): number {
+  if (values.length === 0) return 0;
+
+  let below = 0;
+  let equal = 0;
+  for (const v of values) {
+    if (v < value) below++;
+    else if (v === value) equal++;
+  }
+  return ((below + equal / 2) / values.length) * 100;
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return Math.round(a + (b - a) * t);
+}
+
+function rgbToHex([r, g, b]: [number, number, number]): string {
+  return `#${[r, g, b].map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+}
+
+/** Maps a percentile (0-100) to a color on a red -> amber -> green gradient. */
+export function percentileToColor(percentile: number): string {
+  const p = Math.max(0, Math.min(100, percentile));
+  const [from, to, t] =
+    p <= 50 ? [CRITICAL, WARNING, p / 50] : [WARNING, GOOD, (p - 50) / 50];
+
+  return rgbToHex([lerp(from[0], to[0], t), lerp(from[1], to[1], t), lerp(from[2], to[2], t)]);
+}

--- a/apps/docs/src/components/statistics/deserialize.ts
+++ b/apps/docs/src/components/statistics/deserialize.ts
@@ -53,6 +53,7 @@ export function deserializeProvinces(raw: ColumnarData): ProvinceAggregate[] {
     terrain_type:             r[idx.terrain_type]             as string,
     is_coastal:               r[idx.is_coastal]               as boolean,
     region:                   r[idx.region]                   as string,
+    original_owner_nation:    (r[idx.original_owner_nation]   as string | null | undefined) ?? null,
     games_appeared:           r[idx.games_appeared]           as number,
     avg_ownership_changes:    r[idx.avg_ownership_changes]    as number,
     contest_frequency:        r[idx.contest_frequency]        as number,

--- a/apps/docs/src/components/statistics/deserialize.ts
+++ b/apps/docs/src/components/statistics/deserialize.ts
@@ -1,10 +1,12 @@
 import type {
   BuildingAggregate,
   BuildingTimeSeriesPoint,
+  ClusterInfo,
   ColumnarData,
   CountryAggregate,
   CountryTimeSeries,
   MoraleTimeSeriesPoint,
+  NationSimilarityAggregate,
   PlayerActivityPoint,
   ProvinceAggregate,
   ProductionTimeSeriesPoint,
@@ -16,6 +18,7 @@ export function deserializeCountries(raw: ColumnarData): CountryAggregate[] {
   return raw.rows.map((r) => ({
     nation_name:           r[idx.nation_name]           as string,
     games_played:          r[idx.games_played]          as number,
+    human_games_played:    (r[idx.human_games_played]   as number | undefined) ?? 0,
     wins:                  r[idx.wins]                  as number,
     win_rate:              r[idx.win_rate]              as number,
     avg_final_vp:          r[idx.avg_final_vp]          as number,
@@ -75,6 +78,22 @@ export function deserializeBuildings(raw: ColumnarData): BuildingAggregate[] {
     avg_level:          r[idx.avg_level]          as number,
     avg_per_tier:       (r[idx.avg_per_tier] ?? {}) as Record<string, number>,
   }));
+}
+
+export function deserializeNationSimilarity(
+  raw: ColumnarData & { clusters: ClusterInfo[] },
+): { nations: NationSimilarityAggregate[]; clusters: ClusterInfo[] } {
+  const idx = Object.fromEntries(raw.columns.map((c, i) => [c, i]));
+  const nations = raw.rows.map((r) => ({
+    nation_name:         r[idx.nation_name]         as string,
+    games_played:        r[idx.games_played]        as number,
+    human_games_played:  r[idx.human_games_played]  as number,
+    cluster_id:          r[idx.cluster_id]          as number,
+    pca_x:                r[idx.pca_x]              as number,
+    pca_y:                r[idx.pca_y]              as number,
+    top_buildings:       (r[idx.top_buildings]      as string[] | undefined) ?? [],
+  }));
+  return { nations, clusters: raw.clusters ?? [] };
 }
 
 type BucketSeries = Record<string, { avg: (number | null)[]; n: (number | null)[] }>;

--- a/apps/docs/src/components/statistics/deserialize.ts
+++ b/apps/docs/src/components/statistics/deserialize.ts
@@ -52,6 +52,7 @@ export function deserializeProvinces(raw: ColumnarData): ProvinceAggregate[] {
     province_name:            r[idx.province_name]            as string,
     terrain_type:             r[idx.terrain_type]             as string,
     is_coastal:               r[idx.is_coastal]               as boolean,
+    region:                   r[idx.region]                   as string,
     games_appeared:           r[idx.games_appeared]           as number,
     avg_ownership_changes:    r[idx.avg_ownership_changes]    as number,
     contest_frequency:        r[idx.contest_frequency]        as number,

--- a/apps/docs/src/components/statistics/sections/BuildingsSection.tsx
+++ b/apps/docs/src/components/statistics/sections/BuildingsSection.tsx
@@ -2,16 +2,19 @@ import React from 'react';
 import BuildingFrequencyChart from '../charts/BuildingFrequencyChart';
 import BuildingProgressionChart from '../charts/BuildingProgressionChart';
 import CountryBuildingChart from '../charts/CountryBuildingChart';
-import type { BuildingAggregate, CountryAggregate, TimeSeriesOutput } from '../types';
+import CountrySimilarityScatterChart from '../charts/CountrySimilarityScatterChart';
+import type { BuildingAggregate, ClusterInfo, CountryAggregate, NationSimilarityAggregate, TimeSeriesOutput } from '../types';
 import styles from './Section.module.css';
 
 interface Props {
   data: BuildingAggregate[];
   countries: CountryAggregate[];
   timeseries: TimeSeriesOutput;
+  similarity: NationSimilarityAggregate[];
+  clusters: ClusterInfo[];
 }
 
-export default function BuildingsSection({ data, countries, timeseries }: Props) {
+export default function BuildingsSection({ data, countries, timeseries, similarity, clusters }: Props) {
   if (data.length === 0) return null;
 
   return (
@@ -44,6 +47,16 @@ export default function BuildingsSection({ data, countries, timeseries }: Props)
             pct_buckets={timeseries.pct_buckets}
           />
         </div>
+        {similarity.length > 0 && (
+          <div id="chart-buildings-similarity" className={styles.chartCard} style={{ gridColumn: '1 / -1' }}>
+            <h3 className={styles.chartTitle}>Nation Build Similarity</h3>
+            <p className={styles.chartSubtitle}>
+              Nations clustered by build composition (buildings normalized to % of that nation&apos;s builds, then PCA + k-means) ·
+              restricted to nations with at least a handful of human-played games · dot color = build-style cluster
+            </p>
+            <CountrySimilarityScatterChart data={similarity} clusters={clusters} />
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/docs/src/components/statistics/sections/CountryStatsSection.tsx
+++ b/apps/docs/src/components/statistics/sections/CountryStatsSection.tsx
@@ -32,12 +32,11 @@ export default function CountryStatsSection({ data, timeseries }: Props) {
       <div className={styles.grid}>
         <div id="chart-countries-vp" className={styles.chartCard} style={{ gridColumn: '1 / -1' }}>
           <h3 className={styles.chartTitle}>Victory Point Progression (Top 10 Nations)</h3>
-          <p className={styles.chartSubtitle}>Avg VP at each point in the game for the top 10 nations by win rate · use buttons to switch time axis</p>
+          <p className={styles.chartSubtitle}>Avg VP at each point in the game for the top 10 nations by win rate</p>
           <CountryVPTimeSeriesChart data={timeseries} countries={data} topN={10} />
         </div>
         <div id="chart-countries-winrate" className={styles.chartCard}>
           <h3 className={styles.chartTitle}>Win Rate by Country (Top 20)</h3>
-          <p className={styles.chartSubtitle}>% of games won · coloured by performance tier</p>
           <CountryWinRateChart data={data} topN={20} />
         </div>
         <div id="chart-countries-territory" className={styles.chartCard}>

--- a/apps/docs/src/components/statistics/sections/GlobalStatsSection.tsx
+++ b/apps/docs/src/components/statistics/sections/GlobalStatsSection.tsx
@@ -33,20 +33,10 @@ export default function GlobalStatsSection({ data, timeseries }: Props) {
         </div>
         <div id="chart-global-victory" className={styles.chartCard}>
           <h3 className={styles.chartTitle}>Victory Types</h3>
-          <p className={styles.chartSubtitle}>How games were won</p>
-          <VictoryTypeChart data={data.victory_type_distribution} />
-        </div>
-        <div id="chart-global-traitors" className={styles.chartCard}>
-          <h3 className={styles.chartTitle}>Traitor Wins</h3>
           <p className={styles.chartSubtitle}>
-            Solo wins where the winner left a coalition in the final 3 in-game days
+            How games were won — a "traitor" win is a solo victory where the winner left a coalition in the final 3 in-game days
           </p>
-          <div className={styles.statCallout}>
-            <div className={styles.statValue}>{(data.total_traitor_wins ?? 0).toLocaleString()}</div>
-            <div className={styles.statCaption}>
-              {((data.traitor_win_rate ?? 0) * 100).toFixed(0)}% of solo wins came from betraying a coalition right before the win
-            </div>
-          </div>
+          <VictoryTypeChart data={data.victory_type_distribution} totalTraitorWins={data.total_traitor_wins} />
         </div>
         <div id="chart-global-dropout" className={styles.chartCard}>
           <h3 className={styles.chartTitle}>Player Dropout</h3>

--- a/apps/docs/src/components/statistics/sections/GlobalStatsSection.tsx
+++ b/apps/docs/src/components/statistics/sections/GlobalStatsSection.tsx
@@ -19,9 +19,6 @@ export default function GlobalStatsSection({ data, timeseries }: Props) {
   return (
     <section id="section-global" className={styles.section}>
       <h2 className={styles.heading}>Global Overview</h2>
-      <p className={styles.description}>
-        Patterns across all {data.total_games.toLocaleString()} recorded games.
-      </p>
       <div className={styles.grid}>
         <div id="chart-global-duration" className={styles.chartCard}>
           <h3 className={styles.chartTitle}>Game Duration Distribution</h3>
@@ -39,6 +36,18 @@ export default function GlobalStatsSection({ data, timeseries }: Props) {
           <p className={styles.chartSubtitle}>How games were won</p>
           <VictoryTypeChart data={data.victory_type_distribution} />
         </div>
+        <div id="chart-global-traitors" className={styles.chartCard}>
+          <h3 className={styles.chartTitle}>Traitor Wins</h3>
+          <p className={styles.chartSubtitle}>
+            Solo wins where the winner left a coalition in the final 3 in-game days
+          </p>
+          <div className={styles.statCallout}>
+            <div className={styles.statValue}>{(data.total_traitor_wins ?? 0).toLocaleString()}</div>
+            <div className={styles.statCaption}>
+              {((data.traitor_win_rate ?? 0) * 100).toFixed(0)}% of solo wins came from betraying a coalition right before the win
+            </div>
+          </div>
+        </div>
         <div id="chart-global-dropout" className={styles.chartCard}>
           <h3 className={styles.chartTitle}>Player Dropout</h3>
           <p className={styles.chartSubtitle}>
@@ -55,12 +64,12 @@ export default function GlobalStatsSection({ data, timeseries }: Props) {
         </div>
         <div id="chart-global-activity" className={styles.chartCard} style={{ gridColumn: '1 / -1' }}>
           <h3 className={styles.chartTitle}>Player Activity Over Time</h3>
-          <p className={styles.chartSubtitle}>Avg alive players and active humans at each point in a typical game · use buttons to switch time axis</p>
+          <p className={styles.chartSubtitle}>Avg alive players and active humans at each point in a typical game</p>
           <PlayerActivityTimeSeriesChart data={timeseries} />
         </div>
         <div id="chart-global-coalition-size" className={styles.chartCard}>
           <h3 className={styles.chartTitle}>Coalition Size Distribution</h3>
-          <p className={styles.chartSubtitle}>How many players shared the win — solo vs 2-, 3-, or more-player coalitions</p>
+          <p className={styles.chartSubtitle}>How many players shared the win</p>
           <CoalitionSizeDistributionChart data={data} />
         </div>
         <div id="chart-global-coalition-pairs" className={styles.chartCard}>

--- a/apps/docs/src/components/statistics/sections/ProvinceStatsSection.tsx
+++ b/apps/docs/src/components/statistics/sections/ProvinceStatsSection.tsx
@@ -43,7 +43,7 @@ export default function ProvinceStatsSection({ data }: Props) {
       <div className={styles.grid}>
         <div id="chart-provinces-strategic" className={styles.chartCard} style={{ gridColumn: '1 / -1' }}>
           <h3 className={styles.chartTitle}>Province Strategic Map</h3>
-          <p className={styles.chartSubtitle}>Urban provinces · avg ownership changes per game vs winner control rate · reference lines at medians · top outliers labeled · coloured by region</p>
+          <p className={styles.chartSubtitle}>Cities · avg ownership changes per game vs winner control rate · reference lines at medians · coloured by region</p>
           <ProvinceStrategicScatterChart data={filtered} />
         </div>
       </div>

--- a/apps/docs/src/components/statistics/sections/ProvinceStatsSection.tsx
+++ b/apps/docs/src/components/statistics/sections/ProvinceStatsSection.tsx
@@ -10,7 +10,9 @@ interface Props {
 export default function ProvinceStatsSection({ data }: Props) {
   const [showCoastal, setShowCoastal] = useState<'all' | 'land' | 'coastal'>('all');
 
-  const filtered = data.filter((p) => {
+  const urban = data.filter((p) => p.terrain_type === 'URBAN');
+
+  const filtered = urban.filter((p) => {
     if (showCoastal === 'coastal') return p.is_coastal;
     if (showCoastal === 'land') return !p.is_coastal;
     return true;
@@ -22,7 +24,7 @@ export default function ProvinceStatsSection({ data }: Props) {
         <div>
           <h2 className={styles.heading}>Province Analysis</h2>
           <p className={styles.description}>
-            Strategic importance and contest patterns across {data.length} provinces.
+            Strategic importance and contest patterns across {urban.length} urban provinces.
           </p>
         </div>
         <div className={styles.filter}>
@@ -32,7 +34,7 @@ export default function ProvinceStatsSection({ data }: Props) {
             value={showCoastal}
             onChange={(e) => setShowCoastal(e.target.value as 'all' | 'land' | 'coastal')}
           >
-            <option value="all">All provinces</option>
+            <option value="all">All cities</option>
             <option value="land">Inland only</option>
             <option value="coastal">Coastal only</option>
           </select>
@@ -41,7 +43,7 @@ export default function ProvinceStatsSection({ data }: Props) {
       <div className={styles.grid}>
         <div id="chart-provinces-strategic" className={styles.chartCard} style={{ gridColumn: '1 / -1' }}>
           <h3 className={styles.chartTitle}>Province Strategic Map</h3>
-          <p className={styles.chartSubtitle}>All provinces · avg ownership changes per game vs winner control rate · reference lines at medians · top outliers labeled · coloured by terrain type</p>
+          <p className={styles.chartSubtitle}>Urban provinces · avg ownership changes per game vs winner control rate · reference lines at medians · top outliers labeled · coloured by region</p>
           <ProvinceStrategicScatterChart data={filtered} />
         </div>
       </div>

--- a/apps/docs/src/components/statistics/sections/Section.module.css
+++ b/apps/docs/src/components/statistics/sections/Section.module.css
@@ -76,3 +76,26 @@
   outline: 2px solid var(--ifm-color-primary);
   outline-offset: 1px;
 }
+
+.statCallout {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1rem 0;
+}
+
+.statValue {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+  line-height: 1.1;
+}
+
+.statCaption {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+  margin-top: 0.5rem;
+  max-width: 26ch;
+}

--- a/apps/docs/src/components/statistics/sections/Section.module.css
+++ b/apps/docs/src/components/statistics/sections/Section.module.css
@@ -77,25 +77,3 @@
   outline-offset: 1px;
 }
 
-.statCallout {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  padding: 1rem 0;
-}
-
-.statValue {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: var(--ifm-color-primary);
-  line-height: 1.1;
-}
-
-.statCaption {
-  font-size: 0.85rem;
-  color: var(--ifm-color-emphasis-600);
-  margin-top: 0.5rem;
-  max-width: 26ch;
-}

--- a/apps/docs/src/components/statistics/types.ts
+++ b/apps/docs/src/components/statistics/types.ts
@@ -61,6 +61,7 @@ export interface GlobalAggregate {
 export interface CountryAggregate {
   nation_name: string;
   games_played: number;
+  human_games_played: number;
   wins: number;
   win_rate: number;
   avg_final_vp: number;
@@ -87,6 +88,23 @@ export interface CountryAggregate {
   coalition_win_rate?: number;
   avg_winning_coalition_size?: number;
   avg_elimination_pct?: number | null;
+}
+
+export interface ClusterInfo {
+  id: number;
+  label: string;
+  size: number;
+  top_buildings: string[];
+}
+
+export interface NationSimilarityAggregate {
+  nation_name: string;
+  games_played: number;
+  human_games_played: number;
+  cluster_id: number;
+  pca_x: number;
+  pca_y: number;
+  top_buildings: string[];
 }
 
 export interface ProvinceAggregate {

--- a/apps/docs/src/components/statistics/types.ts
+++ b/apps/docs/src/components/statistics/types.ts
@@ -95,6 +95,7 @@ export interface ProvinceAggregate {
   terrain_type: string;
   is_coastal: boolean;
   region: string;
+  original_owner_nation: string | null;
   games_appeared: number;
   avg_ownership_changes: number;
   contest_frequency: number;

--- a/apps/docs/src/components/statistics/types.ts
+++ b/apps/docs/src/components/statistics/types.ts
@@ -54,6 +54,8 @@ export interface GlobalAggregate {
   avg_coalition_size?: number;
   top_coalition_pairs?: [string, string, number][];
   elimination_timing_distribution?: Record<string, number>;
+  total_traitor_wins?: number;
+  traitor_win_rate?: number;
 }
 
 export interface CountryAggregate {
@@ -92,6 +94,7 @@ export interface ProvinceAggregate {
   province_name: string;
   terrain_type: string;
   is_coastal: boolean;
+  region: string;
   games_appeared: number;
   avg_ownership_changes: number;
   contest_frequency: number;

--- a/apps/docs/src/pages/statistics/index.tsx
+++ b/apps/docs/src/pages/statistics/index.tsx
@@ -10,14 +10,17 @@ import ProvinceStatsSection from '../../components/statistics/sections/ProvinceS
 import {
   deserializeBuildings,
   deserializeCountries,
+  deserializeNationSimilarity,
   deserializeProvinces,
   deserializeTimeSeries,
 } from '../../components/statistics/deserialize';
 import type {
   BuildingAggregate,
+  ClusterInfo,
   CountryAggregate,
   GlobalAggregate,
   MetaInfo,
+  NationSimilarityAggregate,
   ProvinceAggregate,
   TimeSeriesOutput,
 } from '../../components/statistics/types';
@@ -30,6 +33,8 @@ interface StatsData {
   meta: MetaInfo;
   timeseries: TimeSeriesOutput;
   buildings: BuildingAggregate[];
+  nationSimilarity: NationSimilarityAggregate[];
+  buildClusters: ClusterInfo[];
 }
 
 const STATS_BASE_URL = process.env.NODE_ENV === 'development'
@@ -37,14 +42,16 @@ const STATS_BASE_URL = process.env.NODE_ENV === 'development'
   : 'https://r2.conlyse.zdox.dev/stats';
 
 async function fetchStats(): Promise<StatsData> {
-  const [global, countriesRaw, provincesRaw, meta, timeseriesRaw, buildingsRaw] = await Promise.all([
+  const [global, countriesRaw, provincesRaw, meta, timeseriesRaw, buildingsRaw, nationSimilarityRaw] = await Promise.all([
     fetch(`${STATS_BASE_URL}/global.json`).then((r) => r.json()),
     fetch(`${STATS_BASE_URL}/countries.json`).then((r) => r.json()),
     fetch(`${STATS_BASE_URL}/provinces.json`).then((r) => r.json()),
     fetch(`${STATS_BASE_URL}/meta.json`).then((r) => r.json()),
     fetch(`${STATS_BASE_URL}/timeseries.json`).then((r) => r.json()),
     fetch(`${STATS_BASE_URL}/buildings.json`).then((r) => r.json()),
+    fetch(`${STATS_BASE_URL}/nation_similarity.json`).then((r) => r.json()),
   ]);
+  const { nations: nationSimilarity, clusters: buildClusters } = deserializeNationSimilarity(nationSimilarityRaw);
   return {
     global,
     countries: deserializeCountries(countriesRaw),
@@ -52,6 +59,8 @@ async function fetchStats(): Promise<StatsData> {
     meta,
     timeseries: deserializeTimeSeries(timeseriesRaw),
     buildings: deserializeBuildings(buildingsRaw),
+    nationSimilarity,
+    buildClusters,
   };
 }
 
@@ -97,7 +106,13 @@ export default function StatisticsPage() {
               <CountryStatsSection data={data.countries} timeseries={data.timeseries} />
               <EconomicStatsSection global={data.global} countries={data.countries} timeseries={data.timeseries} />
               <ProvinceStatsSection data={data.provinces} />
-              <BuildingsSection data={data.buildings} countries={data.countries} timeseries={data.timeseries} />
+              <BuildingsSection
+                data={data.buildings}
+                countries={data.countries}
+                timeseries={data.timeseries}
+                similarity={data.nationSimilarity}
+                clusters={data.buildClusters}
+              />
             </>
           )}
         </main>

--- a/libs/conflict_interface/conflict_interface/game_object/game_object_binary.py
+++ b/libs/conflict_interface/conflict_interface/game_object/game_object_binary.py
@@ -160,7 +160,12 @@ class GameObjectSerializer:
 
         if t is dict:
             from_raw = self._from_raw
-            return {from_raw(k): from_raw(v) for k, v in data["__dict__"]}
+            primitives = self._PRIMITIVES
+            return {
+                (k if type(k) in primitives else from_raw(k)):
+                    (v if type(v) in primitives else from_raw(v))
+                for k, v in data["__dict__"]
+            }
 
 
         if t is list:
@@ -170,7 +175,8 @@ class GameObjectSerializer:
             else:
                 # Plain list
                 from_raw = self._from_raw
-                return [from_raw(v) for v in data]
+                primitives = self._PRIMITIVES
+                return [v if type(v) in primitives else from_raw(v) for v in data]
 
         raise TypeError(f"Cannot deserialize:  {type(data)} \n {str(data)[:1000]}")
 
@@ -187,19 +193,29 @@ class GameObjectSerializer:
             )
         cat = self._category[cls]
         from_raw = self._from_raw
+        # Avoid a full recursive _from_raw call (frame setup + branch tree)
+        # for the common case of an already-primitive field value.
+        primitives = self._PRIMITIVES
 
         if cat in (SerializationCategory.DATACLASS, SerializationCategory.GAME_STATE, SerializationCategory.STATIC_MAP_DATA):
             field_names = self._fields[cls]
-            kwargs = {name: from_raw(data[i + 2]) for i, name in enumerate(field_names)}
+            kwargs = {}
+            for i, name in enumerate(field_names):
+                v = data[i + 2]
+                kwargs[name] = v if type(v) in primitives else from_raw(v)
             instance = cls(**kwargs)
             instance.game = None
             return instance
 
         elif cat == SerializationCategory.LIST:
-            return cls([from_raw(v) for v in data[2]])
+            return cls([v if type(v) in primitives else from_raw(v) for v in data[2]])
 
         elif cat == SerializationCategory.DICT:
-            return cls({from_raw(pair[0]): from_raw(pair[1]) for pair in data[2]})
+            return cls({
+                (pair[0] if type(pair[0]) in primitives else from_raw(pair[0])):
+                    (pair[1] if type(pair[1]) in primitives else from_raw(pair[1]))
+                for pair in data[2]
+            })
 
         elif cat == SerializationCategory.DATETIME:
             return cls.fromtimestamp(data[2], UTC)

--- a/scripts/extract_stats.slurm
+++ b/scripts/extract_stats.slurm
@@ -2,7 +2,7 @@
 #SBATCH --job-name=game-stats-extractor
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=48
-#SBATCH --mem=96G
+#SBATCH --mem-per-cpu=1500M
 #SBATCH --time=02:00:00
 #SBATCH --tmp=100g
 #SBATCH --output=%x_%j.out

--- a/scripts/replay_healthcheck.slurm
+++ b/scripts/replay_healthcheck.slurm
@@ -2,7 +2,7 @@
 #SBATCH --job-name=replay-healthcheck
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=48
-#SBATCH --mem=96G
+#SBATCH --mem-per-cpu=2G
 #SBATCH --time=04:00:00
 #SBATCH --tmp=100g
 #SBATCH --output=%x_%j.out

--- a/scripts/replay_healthcheck.slurm
+++ b/scripts/replay_healthcheck.slurm
@@ -1,0 +1,45 @@
+#!/bin/bash
+#SBATCH --job-name=replay-healthcheck
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=48
+#SBATCH --mem=96G
+#SBATCH --time=04:00:00
+#SBATCH --tmp=100g
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -e
+
+echo "[$(date)] Job started on $(hostname)"
+
+# Load Python
+echo "[$(date)] Loading modules..."
+module load stack/2024-06
+module load python/3.12.8
+
+# Activate environment
+echo "[$(date)] Activating virtual environment..."
+cd $HOME/conlyse
+source venv/bin/activate
+
+# Copy input data to node-local storage
+echo "[$(date)] Copying replays to node-local storage..."
+rsync -aq ${SCRATCH}/replays/ ${TMPDIR}/replays/
+
+echo "[$(date)] Copying map data to node-local storage..."
+rsync -aq ${SCRATCH}/static_maps/ ${TMPDIR}/static_maps/
+
+# Run health check
+echo "[$(date)] Running replay_healthcheck..."
+python scripts/replay_healthcheck/__main__.py \
+    --replays-dir "${TMPDIR}/replays" \
+    --map-data-dir "${TMPDIR}/static_maps" \
+    --workers "${SLURM_CPUS_PER_TASK}" \
+    --output-dir "${TMPDIR}/health_report"
+
+# Copy the HTML + JSON reports back to scratch
+echo "[$(date)] Copying health report back to SCRATCH..."
+mkdir -p "${SCRATCH}/replay_health_reports/${SLURM_JOB_ID}"
+rsync -aq "${TMPDIR}/health_report/" "${SCRATCH}/replay_health_reports/${SLURM_JOB_ID}/"
+
+echo "[$(date)] Job finished!"

--- a/scripts/replay_healthcheck/__init__.py
+++ b/scripts/replay_healthcheck/__init__.py
@@ -1,0 +1,4 @@
+"""Replay health check — analyzes a local folder of replay files.
+
+See __main__.py for CLI usage.
+"""

--- a/scripts/replay_healthcheck/__main__.py
+++ b/scripts/replay_healthcheck/__main__.py
@@ -1,0 +1,101 @@
+"""
+Replay health check — analyzes a local folder of replay files.
+
+  python scripts/replay_healthcheck/__main__.py --replays-dir data/prod_replays
+
+What it does:
+  1. Discovers game_<id>_player_<id>.conrp files in --replays-dir (assumed to
+     already be in the current v3 container format — no auto-migration)
+  2. Runs a staged analysis per replay: file existence, metadata, datatype
+     version compatibility, structural integrity, then (if static map data
+     is available) a full parse for game-content quality — classifying each
+     replay as OK / DEGRADED / FAILED with a specific reason
+  3. Prints a detailed terminal report
+  4. Writes replay_health_report.html (charts) and replay_health.json
+     (machine-readable export) to --output-dir
+
+Dependencies (pip install if missing):
+  tqdm  matplotlib  numpy  conflict_interface (or repo on PYTHONPATH)
+
+Optional:
+  --map-data-dir points at a directory of static map .bin files (default:
+  data/maps_dir). Without static map data for a given replay's map_id, that
+  replay only reaches "metadata_only" depth — file-integrity and version
+  checks still run, but game-content quality checks (ranking, provinces,
+  coverage, players) are skipped rather than misreported.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_THIS_DIR = Path(__file__).resolve().parent
+_SCRIPTS_DIR = _THIS_DIR.parent
+REPO_ROOT = _SCRIPTS_DIR.parent
+
+sys.path.insert(0, str(REPO_ROOT / "libs" / "conflict_interface"))
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from replay_healthcheck.analyze import analyze_replays  # noqa: E402
+from replay_healthcheck.discovery import discover_replays  # noqa: E402
+from replay_healthcheck.report_html import generate_health_report  # noqa: E402
+from replay_healthcheck.report_json import write_json_report  # noqa: E402
+from replay_healthcheck.report_text import print_report  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Replay health check — analyzes a local folder of replays and reports coverage/quality metrics",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--replays-dir", required=True, type=Path,
+        help="Directory containing game_<id>_player_<id>.conrp replay files",
+    )
+    parser.add_argument(
+        "--map-data-dir", type=Path, default=REPO_ROOT / "data" / "maps_dir",
+        help="Directory containing static map .bin files (default: data/maps_dir)",
+    )
+    parser.add_argument(
+        "--workers", type=int, default=None,
+        help="Number of worker processes for replay parsing (default: CPU count)",
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, default=Path.cwd(),
+        help="Directory to write replay_health_report.html and replay_health.json (default: current directory)",
+    )
+    args = parser.parse_args()
+
+    if not args.replays_dir.is_dir():
+        sys.exit(f"ERROR: replays-dir does not exist: {args.replays_dir}")
+
+    rows = discover_replays(args.replays_dir)
+    if not rows:
+        print("No replay files found — nothing to analyse.")
+        sys.exit(0)
+
+    static_map_data: dict = {}
+    if args.map_data_dir and args.map_data_dir.exists():
+        static_map_data = {p.stem: p for p in args.map_data_dir.glob("*.bin")}
+    else:
+        print(
+            f"  Note: {args.map_data_dir} not found — replays will only reach "
+            f"metadata_only depth (file-integrity/version checks only)",
+            flush=True,
+        )
+
+    import os
+    workers = args.workers or os.cpu_count() or 1
+
+    print(f"\nAnalysing {len(rows)} replays ...", flush=True)
+    results = analyze_replays(rows, static_map_data=static_map_data, workers=workers)
+
+    print_report(results)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    generate_health_report(results, args.output_dir / "replay_health_report.html")
+    write_json_report(results, args.output_dir / "replay_health.json", args.replays_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/replay_healthcheck/aggregate.py
+++ b/scripts/replay_healthcheck/aggregate.py
@@ -1,0 +1,31 @@
+"""Cross-replay aggregation helpers."""
+
+from collections import Counter, defaultdict
+
+from .models import ReplayHealth
+
+
+def province_consistency(results: list[ReplayHealth]) -> dict[str, dict]:
+    """Group replays by map_id and compare each replay's province set against
+    the authoritative set from static map data."""
+    by_map: dict[str, list[ReplayHealth]] = defaultdict(list)
+    for r in results:
+        if r.map_id and r.province_ids is not None:
+            by_map[r.map_id].append(r)
+
+    consistency: dict[str, dict] = {}
+    for map_id, entries in by_map.items():
+        expected_sets = [r.expected_province_ids for r in entries if r.expected_province_ids]
+        expected = expected_sets[0] if expected_sets else None
+        counts = [len(r.province_ids) for r in entries]
+        missing_counter: Counter = Counter()
+        if expected is not None:
+            for r in entries:
+                missing_counter.update(expected - r.province_ids)
+        consistency[map_id] = {
+            "n_games": len(entries),
+            "expected_count": len(expected) if expected is not None else None,
+            "counts": counts,
+            "missing_counter": missing_counter,
+        }
+    return consistency

--- a/scripts/replay_healthcheck/analyze.py
+++ b/scripts/replay_healthcheck/analyze.py
@@ -1,0 +1,232 @@
+"""Staged per-replay health analysis.
+
+Each stage only runs if the previous one succeeded. A failure at any stage
+stops further stages and returns a FAILED result with a specific
+FailureCategory + detail message, instead of a single generic
+`except Exception` bucket.
+"""
+
+import statistics
+from datetime import timedelta
+
+from conflict_interface.interface.replay_interface import ReplayInterface
+
+from .compat import unsupported_versions
+from .models import FailureCategory, ReplayHealth, ReplayRow, Status
+
+# A delta between consecutive recorded timestamps larger than
+# GAP_FACTOR * (median delta for that replay) is treated as a recording gap.
+GAP_FACTOR = 4.25
+
+_VALID_ACTIVITY_STATES = {"ACTIVE", "UNKNOWN", "INACTIVE", "ABANDONED"}
+
+
+def _fail(r: ReplayHealth, category: FailureCategory, detail: str) -> ReplayHealth:
+    r.status = Status.FAILED
+    r.failure_category = category
+    r.failure_detail = detail
+    return r
+
+
+def _classify_parse_error(msg: str) -> FailureCategory:
+    """Classify an exception raised during a full parse by message content.
+
+    `GameObjectSerializer._from_raw_registered` raises a raw, unwrapped
+    "Unknown type_id ..." KeyError when a replay's embedded objects use a
+    finer-grained type that isn't registered for its GameState version — a
+    real schema-version mismatch that Stage 2's coarse whole-version check
+    (get_required_versions() vs get_supported_datatype_versions()) can't
+    catch, since the outer GameState version itself may still be "supported"
+    even though a specific object type within it isn't.
+    """
+    if "lz4 decompression failed" in msg:
+        return FailureCategory.CORRUPTED_SEGMENT
+    if "Unknown type_id" in msg:
+        return FailureCategory.VERSION_INCOMPATIBLE
+    return FailureCategory.UNEXPECTED_ERROR
+
+
+def analyze_one(row: ReplayRow, static_map_data: dict) -> ReplayHealth:
+    """Run the staged health analysis for a single replay file.
+
+    Runs in a worker process — must be picklable/standalone.
+    """
+    path = row.path
+    name = path.stem
+    r = ReplayHealth(game_id=row.game_id, player_id=row.player_id, name=name)
+
+    # Stage 0 — existence
+    if not path.exists():
+        return _fail(r, FailureCategory.FILE_NOT_FOUND, f"{path} does not exist")
+
+    # Stage 1 — metadata open (cheap, no static map data needed)
+    try:
+        ri = ReplayInterface(path)
+        ri.open(mode="read_metadata")
+    except ValueError as e:
+        msg = str(e)
+        if "Unsupported replay format version" in msg:
+            return _fail(r, FailureCategory.UNSUPPORTED_CONTAINER_VERSION, msg)
+        if "magic" in msg.lower():
+            return _fail(r, FailureCategory.NOT_A_REPLAY, msg)
+        return _fail(r, FailureCategory.UNEXPECTED_ERROR, msg)
+    except Exception as e:
+        return _fail(r, FailureCategory.UNEXPECTED_ERROR, str(e))
+
+    try:
+        meta = ri.get_timeline_metadata()
+        if meta is not None:
+            r.segment_count = meta.segment_count
+        r.patches = ri.get_total_patches()
+        r.seg_last_ts = ri.last_time
+        required_map_ids = ri.get_required_map_ids()
+        for (start_dt, _), seg in ri._replay.segments.items():
+            r.seg_first_ts = start_dt
+            m = seg.storage.metadata
+            if m:
+                r.map_id = m.map_id
+            break
+        r.parse_depth = "metadata_only"
+    except Exception as e:
+        ri.close()
+        return _fail(r, FailureCategory.UNEXPECTED_ERROR, str(e))
+
+    # Stage 2 — version compatibility (avoids a raw KeyError mid-parse for
+    # replays recorded with a datatype version this build doesn't support)
+    r.required_versions = ri.get_required_versions()
+    r.unsupported_versions = unsupported_versions(r.required_versions)
+    if r.unsupported_versions:
+        ri.close()
+        return _fail(
+            r,
+            FailureCategory.VERSION_INCOMPATIBLE,
+            f"datatype version(s) {sorted(r.unsupported_versions)} not supported by this "
+            f"build (replay requires: {sorted(r.required_versions)})",
+        )
+
+    ri.close()
+
+    # Stage 3 — structural integrity. This needs each segment's patch tree
+    # deserialized (read_metadata mode never reads the path-tree bytes off
+    # disk at all — only a full open does), so it can only run as part of
+    # the full parse below, not as a cheap metadata-only pre-check.
+
+    # Stage 4 — full parse. Only attempted if static map data covers every
+    # map_id this replay requires; otherwise this is an environment
+    # limitation (no map data supplied), not a defect in the replay itself,
+    # so we leave parse_depth at "metadata_only" and status at OK.
+    if not required_map_ids or not required_map_ids.issubset(static_map_data.keys()):
+        return r
+
+    try:
+        ri = ReplayInterface(path, static_map_data=static_map_data)
+        ri.open(mode="r")
+    except Exception as e:
+        msg = str(e)
+        return _fail(r, _classify_parse_error(msg), msg)
+
+    try:
+        for segment in ri._replay.segments.values():
+            segment.validate_structure()
+    except Exception as e:
+        ri.close()
+        return _fail(r, FailureCategory.STRUCTURALLY_CORRUPTED, str(e))
+
+    try:
+        timestamps = ri.get_timestamps()
+        ri.jump_to(timestamps[0])
+        gi = ri.game_state.states.game_info_state
+        r.start_of_game = gi.start_of_game
+        r.day_first = gi.day_of_game
+        r.time_scale = gi.time_scale
+
+        ri.jump_to(ri.last_time)
+        gi = ri.game_state.states.game_info_state
+        r.day_last = gi.day_of_game
+        r.game_ended = gi.game_ended
+        r.end_of_game = gi.end_of_game
+
+        ranking = ri.game_state.states.newspaper_state.ranking
+        r.ranking_initialized = ranking.initialized if ranking is not None else None
+
+        map_obj = ri.game_state.states.map_state.map
+        r.province_ids = set(map_obj.provinces.keys())
+        static = getattr(map_obj, "static_map_data", None)
+        if static is not None:
+            r.expected_province_ids = set(static.province_to_location.keys())
+
+        players = ri.game_state.states.player_state.players
+        r.player_count = len(players)
+        real_players = [
+            p for p in players.values()
+            if not (p.computer_player or p.native_computer or p.terrorist_country)
+        ]
+        r.real_player_count = len(real_players)
+        r.has_real_players = r.real_player_count > 0
+        # `None` is the overwhelmingly common value here in practice (this field
+        # appears to only be meaningfully populated for the recording player's
+        # own POV, not for every player in the game) — only count genuinely
+        # unexpected non-None values as invalid, not the common None case.
+        r.invalid_activity_state_count = sum(
+            1 for p in players.values()
+            if p.activity_state is not None and p.activity_state not in _VALID_ACTIVITY_STATES
+        )
+
+        r.n_timestamps = len(timestamps)
+        if len(timestamps) >= 2:
+            deltas = [
+                (timestamps[i + 1] - timestamps[i]).total_seconds()
+                for i in range(len(timestamps) - 1)
+            ]
+            typical = statistics.median(deltas)
+            gap_threshold = typical * GAP_FACTOR
+            normal = [d for d in deltas if d <= gap_threshold]
+            gap_intervals = [
+                (timestamps[i], timestamps[i + 1], deltas[i])
+                for i in range(len(deltas))
+                if deltas[i] > gap_threshold
+            ]
+            r.typical_interval = timedelta(seconds=typical)
+            r.gap_count = len(gap_intervals)
+            r.gap_total = timedelta(seconds=sum(d for *_, d in gap_intervals))
+            r.covered_seconds = sum(normal) + typical
+            r.gaps = gap_intervals
+
+        ri.close()
+        r.parse_depth = "full"
+    except Exception as e:
+        msg = str(e)
+        return _fail(r, _classify_parse_error(msg), msg)
+
+    # Final status / degraded-reasons rollup
+    reasons: list[str] = []
+    if not r.game_ended:
+        reasons.append("game_not_ended")
+    if r.ranking_initialized is not True:
+        reasons.append("ranking_not_initialized")
+    if r.expected_province_ids is not None and r.province_ids != r.expected_province_ids:
+        reasons.append("provinces_missing")
+    if r.gap_count > 0:
+        reasons.append("has_recording_gaps")
+    if not r.has_real_players:
+        reasons.append("no_real_players")
+    if r.invalid_activity_state_count:
+        reasons.append("invalid_player_activity_state")
+
+    r.degraded_reasons = reasons
+    r.status = Status.DEGRADED if reasons else Status.OK
+    return r
+
+
+def analyze_replays(rows: list[ReplayRow], static_map_data: dict, workers: int) -> list[ReplayHealth]:
+    from concurrent.futures import ProcessPoolExecutor
+
+    from tqdm import tqdm
+
+    results: list[ReplayHealth] = []
+    with ProcessPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(analyze_one, row, static_map_data) for row in rows]
+        for fut in tqdm(futures, desc="Analysing replays", unit="replay"):
+            results.append(fut.result())
+
+    return results

--- a/scripts/replay_healthcheck/compat.py
+++ b/scripts/replay_healthcheck/compat.py
@@ -1,0 +1,15 @@
+"""Datatype-version compatibility pre-check.
+
+Lets the health check classify a replay as version-incompatible *before*
+attempting a full parse, instead of hitting a raw KeyError mid-parse
+(GameObjectSerializer._from_raw_registered raises "Unknown type_id ..." when
+a replay was recorded with a datatype version this build doesn't have
+registered).
+"""
+
+from conflict_interface.versions import get_supported_datatype_versions
+
+
+def unsupported_versions(required: set[int]) -> set[int]:
+    """Return the subset of `required` datatype versions this build cannot parse."""
+    return required - get_supported_datatype_versions()

--- a/scripts/replay_healthcheck/discovery.py
+++ b/scripts/replay_healthcheck/discovery.py
@@ -1,0 +1,25 @@
+"""Local-folder replay discovery."""
+
+from pathlib import Path
+
+from .models import ReplayRow
+
+
+def _parse_game_player_id(name: str) -> tuple[int | None, int | None]:
+    stem = Path(name).stem  # game_<id>_player_<id>
+    parts = stem.split("_")
+    if len(parts) >= 4:
+        return int(parts[1]), int(parts[3])
+    return None, None
+
+
+def discover_replays(replays_dir: Path) -> list[ReplayRow]:
+    """Find game_<id>_player_<id>.conrp files in a local directory."""
+    files = sorted(replays_dir.glob("game_*_player_*.conrp"))
+    rows: list[ReplayRow] = []
+    for path in files:
+        game_id, player_id = _parse_game_player_id(path.name)
+        rows.append(ReplayRow(game_id=game_id, player_id=player_id, path=path))
+
+    print(f"  Found {len(rows)} replay file(s) in {replays_dir}", flush=True)
+    return rows

--- a/scripts/replay_healthcheck/models.py
+++ b/scripts/replay_healthcheck/models.py
@@ -1,0 +1,83 @@
+"""Shared data structures for the replay health check."""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+
+
+class Status(StrEnum):
+    OK = "OK"
+    DEGRADED = "DEGRADED"
+    FAILED = "FAILED"
+
+
+class FailureCategory(StrEnum):
+    FILE_NOT_FOUND = "FILE_NOT_FOUND"
+    NOT_A_REPLAY = "NOT_A_REPLAY"
+    UNSUPPORTED_CONTAINER_VERSION = "UNSUPPORTED_CONTAINER_VERSION"
+    VERSION_INCOMPATIBLE = "VERSION_INCOMPATIBLE"
+    STRUCTURALLY_CORRUPTED = "STRUCTURALLY_CORRUPTED"
+    CORRUPTED_SEGMENT = "CORRUPTED_SEGMENT"
+    UNEXPECTED_ERROR = "UNEXPECTED_ERROR"
+
+
+@dataclass
+class ReplayRow:
+    """A single discovered replay file, before analysis."""
+    game_id: int | None
+    player_id: int | None
+    path: Path
+
+
+@dataclass
+class ReplayHealth:
+    """Full per-replay analysis result."""
+
+    game_id: int | None
+    player_id: int | None
+    name: str
+
+    status: Status = Status.OK
+    failure_category: FailureCategory | None = None
+    failure_detail: str | None = None
+    # "none" | "metadata_only" | "full" — how far analysis got before either
+    # finishing or being limited by missing static map data (not a defect).
+    parse_depth: str = "none"
+    degraded_reasons: list[str] = field(default_factory=list)
+
+    # Stage 1 — metadata (read_metadata mode, always attempted)
+    segment_count: int | None = None
+    patches: int | None = None
+    map_id: str | None = None
+    seg_first_ts: datetime | None = None
+    seg_last_ts: datetime | None = None
+
+    # Stage 2 — version compatibility
+    required_versions: set[int] = field(default_factory=set)
+    unsupported_versions: set[int] = field(default_factory=set)
+
+    # Stage 4 — full parse (game_info_state / newspaper_state / map_state)
+    start_of_game: datetime | None = None
+    end_of_game: datetime | None = None
+    day_first: int | None = None
+    day_last: int | None = None
+    time_scale: float | None = None
+    game_ended: bool | None = None
+    ranking_initialized: bool | None = None
+    province_ids: set[int] | None = None
+    expected_province_ids: set[int] | None = None
+
+    # Stage 4 — player validation
+    player_count: int | None = None
+    real_player_count: int | None = None
+    has_real_players: bool | None = None
+    invalid_activity_state_count: int | None = None
+
+    # Stage 4 — coverage / gaps
+    n_timestamps: int | None = None
+    typical_interval: timedelta | None = None
+    gap_count: int = 0
+    gap_total: timedelta = field(default_factory=lambda: timedelta(0))
+    covered_seconds: float | None = None
+    gaps: list[tuple[datetime, datetime, float]] = field(default_factory=list)

--- a/scripts/replay_healthcheck/report_html.py
+++ b/scripts/replay_healthcheck/report_html.py
@@ -1,0 +1,425 @@
+"""HTML report with charts."""
+
+import base64
+import io
+from collections import Counter
+from pathlib import Path
+
+from .aggregate import province_consistency
+from .analyze import GAP_FACTOR
+from .models import ReplayHealth, Status
+from .report_text import strip_tz
+
+_HEALTH_REPORT_CSS = """
+body { font-family: -apple-system, "Segoe UI", Roboto, sans-serif; max-width: 1100px;
+       margin: 2rem auto; padding: 0 1rem; color: #1f2937; line-height: 1.5; }
+h1 { font-size: 1.6rem; }
+h2 { margin-top: 2.5rem; border-bottom: 2px solid #e5e7eb; padding-bottom: 0.3rem; }
+table { border-collapse: collapse; margin: 0.75rem 0; font-size: 0.85rem; }
+th, td { border: 1px solid #e5e7eb; padding: 0.3rem 0.55rem; text-align: right; }
+th { background: #f3f4f6; }
+td:first-child, th:first-child { text-align: left; }
+img { max-width: 100%; display: block; margin: 1rem 0; }
+.metrics { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1rem 0; }
+.metric { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px;
+          padding: 0.75rem 1.25rem; min-width: 140px; }
+.metric .label { font-size: 0.78rem; color: #6b7280; text-transform: uppercase; }
+.metric .value { font-size: 1.4rem; font-weight: 600; }
+.note { color: #6b7280; font-size: 0.88rem; }
+"""
+
+
+def generate_health_report(results: list[ReplayHealth], output_path: Path, top_n: int = 20) -> None:
+    """Render an HTML report with charts that visualise overall replay health."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    def fig_to_base64(fig) -> str:
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=110, bbox_inches="tight")
+        plt.close(fig)
+        return base64.b64encode(buf.getvalue()).decode("ascii")
+
+    def img(fig, alt: str) -> str:
+        return f'<img alt="{alt}" src="data:image/png;base64,{fig_to_base64(fig)}">'
+
+    def bar_section(title: str, counts: dict, colors: list[str]) -> str:
+        labels = list(counts.keys())
+        values = list(counts.values())
+        fig, ax = plt.subplots(figsize=(5, 3.5))
+        ax.bar(labels, values, color=colors[: len(labels)])
+        ax.set_ylabel("Replays")
+        ax.set_title(title)
+        return f"<h2>{title}</h2>{img(fig, title.lower())}"
+
+    def hist_section(title: str, values_label: str, values: list[float], color: str, note: str = "") -> str:
+        if not values:
+            return f"<h2>{title}</h2><p class='note'>No data.</p>"
+        fig, ax = plt.subplots(figsize=(7, 4))
+        ax.hist(values, bins=min(30, max(5, len(values) // 2)), color=color, edgecolor="white")
+        ax.set_xlabel(values_label)
+        ax.set_ylabel("Replays")
+        ax.set_title(title)
+        out = f"<h2>{title}</h2>{img(fig, title.lower())}"
+        if note:
+            out += f"<p class='note'>{note}</p>"
+        return out
+
+    full = [r for r in results if r.parse_depth == "full"]
+    failed = [r for r in results if r.status == Status.FAILED]
+    degraded = [r for r in results if r.status == Status.DEGRADED]
+
+    rows = []
+    for r in full:
+        sog = strip_tz(r.start_of_game)
+        eog = strip_tz(r.end_of_game)
+        ft = strip_tz(r.seg_first_ts)
+        lt = strip_tz(r.seg_last_ts)
+        total_game_span = (eog - sog) if sog and eog else None
+        cont_cov_pct = (
+            r.covered_seconds / total_game_span.total_seconds() * 100
+            if r.covered_seconds is not None and total_game_span and total_game_span.total_seconds() > 0
+            else None
+        )
+        span_cov_pct = (
+            (lt - ft).total_seconds() / total_game_span.total_seconds() * 100
+            if ft and lt and total_game_span and total_game_span.total_seconds() > 0
+            else None
+        )
+        rows.append({
+            "label": f"{r.game_id}/{r.player_id}",
+            "typical_interval": r.typical_interval,
+            "gap_count": r.gap_count,
+            "gap_total": r.gap_total,
+            "gaps": r.gaps,
+            "sog": sog,
+            "eog": eog,
+            "cont_cov_pct": cont_cov_pct,
+            "span_cov_pct": span_cov_pct,
+            "ingame_dur": (lt - ft) if ft and lt else None,
+            "lag": (ft - sog) if ft and sog else None,
+            "time_scale": r.time_scale,
+            "game_ended": r.game_ended,
+            "ranking_initialized": r.ranking_initialized,
+            "player_count": r.player_count,
+        })
+
+    with_intervals = [x for x in rows if x["typical_interval"] is not None]
+    with_gaps = [x for x in rows if x["gap_count"] > 0]
+    all_gap_durations_min = [gap[2] / 60.0 for x in rows for gap in x["gaps"]]
+    cont_coverages = [x["cont_cov_pct"] for x in rows if x["cont_cov_pct"] is not None]
+    span_coverages = [x["span_cov_pct"] for x in rows if x["span_cov_pct"] is not None]
+    ended_yes = sum(1 for x in rows if x["game_ended"] is True)
+    ended_no = sum(1 for x in rows if x["game_ended"] is False)
+    ended_unk = sum(1 for x in rows if x["game_ended"] is None)
+    rank_yes = sum(1 for x in rows if x["ranking_initialized"] is True)
+    rank_no = sum(1 for x in rows if x["ranking_initialized"] is False)
+    rank_unk = sum(1 for x in rows if x["ranking_initialized"] is None)
+
+    sections: list[str] = []
+
+    # 1. Overall status breakdown
+    status_counts = Counter(r.status for r in results)
+    sections.append(bar_section(
+        "Overall status",
+        {s.value: status_counts.get(s, 0) for s in (Status.OK, Status.DEGRADED, Status.FAILED)},
+        ["#16a34a", "#f59e0b", "#dc2626"],
+    ))
+
+    # 2. Failure category breakdown
+    if failed:
+        cat_counts = Counter(r.failure_category.value for r in failed)
+        fig, ax = plt.subplots(figsize=(7, max(3, 0.4 * len(cat_counts))))
+        labels = list(cat_counts.keys())
+        values = list(cat_counts.values())
+        ax.barh(labels, values, color="#dc2626")
+        ax.set_xlabel("Replays")
+        ax.set_title("Failure categories")
+        sections.append(f"<h2>Failure categories</h2>{img(fig, 'failure categories')}")
+
+    # 3. Degraded-reason breakdown
+    if degraded:
+        reason_counts: Counter = Counter()
+        for r in degraded:
+            reason_counts.update(r.degraded_reasons)
+        fig, ax = plt.subplots(figsize=(7, max(3, 0.4 * len(reason_counts))))
+        labels = list(reason_counts.keys())
+        values = list(reason_counts.values())
+        ax.barh(labels, values, color="#f59e0b")
+        ax.set_xlabel("Replays")
+        ax.set_title("Degraded reasons (not mutually exclusive)")
+        sections.append(f"<h2>Degraded reasons</h2>{img(fig, 'degraded reasons')}")
+
+    # 4. Coverage distribution (continuity vs span coverage, overlaid)
+    if cont_coverages or span_coverages:
+        fig, ax = plt.subplots(figsize=(7, 4))
+        bins = np.linspace(
+            min(cont_coverages + span_coverages, default=0),
+            max(cont_coverages + span_coverages, default=100),
+            30,
+        )
+        if span_coverages:
+            ax.hist(span_coverages, bins=bins, color="#2563eb", alpha=0.5, edgecolor="white", label="span coverage")
+        if cont_coverages:
+            ax.hist(cont_coverages, bins=bins, color="#dc2626", alpha=0.5, edgecolor="white", label="continuity coverage")
+        ax.set_xlabel("Coverage of total game span (%)")
+        ax.set_ylabel("Replays")
+        ax.set_title("Distribution of coverage across replays")
+        ax.legend(loc="upper left")
+        note = ""
+        if span_coverages:
+            note += (
+                f"span_cov% — avg {np.mean(span_coverages):.1f}% &nbsp;"
+                f"median {np.median(span_coverages):.1f}% &nbsp;"
+                f"min {np.min(span_coverages):.1f}% &nbsp;"
+                f"max {np.max(span_coverages):.1f}%<br>"
+            )
+        if cont_coverages:
+            note += (
+                f"cont_cov% — avg {np.mean(cont_coverages):.1f}% &nbsp;"
+                f"median {np.median(cont_coverages):.1f}% &nbsp;"
+                f"min {np.min(cont_coverages):.1f}% &nbsp;"
+                f"max {np.max(cont_coverages):.1f}%"
+            )
+        sections.append(
+            f"<h2>Coverage distribution</h2>{img(fig, 'coverage distribution histogram')}"
+            f"<p class='note'>{note}</p>"
+        )
+
+    # 5. Span coverage vs continuity coverage
+    span_vs_cont = [
+        (x["span_cov_pct"], x["cont_cov_pct"]) for x in rows
+        if x["span_cov_pct"] is not None and x["cont_cov_pct"] is not None
+    ]
+    if span_vs_cont:
+        xs, ys = zip(*span_vs_cont)
+        fig, ax = plt.subplots(figsize=(6, 6))
+        ax.scatter(xs, ys, alpha=0.6, color="#2563eb")
+        lim = (0, 105)
+        ax.plot(lim, lim, "--", color="#9ca3af", label="span_cov% = cont_cov%")
+        ax.set_xlim(lim)
+        ax.set_ylim(lim)
+        ax.set_xlabel("span_cov%  (first→last span / total game span)")
+        ax.set_ylabel("cont_cov%  (gap-aware continuity coverage)")
+        ax.set_title("Continuity coverage vs. span coverage")
+        ax.legend(loc="lower right")
+        sections.append(
+            f"<h2>Coverage — how much of each game was actually recorded</h2>"
+            f"{img(fig, 'span vs continuity coverage scatter')}"
+        )
+
+    # 6. In-game time span recorded
+    sections.append(hist_section(
+        "In-game time span recorded",
+        "In-game span recorded (days, seg_last − seg_first, game-universe time)",
+        [x["ingame_dur"].total_seconds() / 86400.0 for x in rows if x["ingame_dur"] is not None],
+        "#16a34a",
+    ))
+
+    # 7. Recording lag
+    sections.append(hist_section(
+        "Recording lag",
+        "Lag before recording started (hours, game-universe time)",
+        [x["lag"].total_seconds() / 3600.0 for x in rows if x["lag"] is not None],
+        "#f59e0b",
+    ))
+
+    # 8. Game end-state
+    fig, ax = plt.subplots(figsize=(5, 3.5))
+    ax.bar(["YES", "no", "unknown"], [ended_yes, ended_no, ended_unk], color=["#16a34a", "#dc2626", "#9ca3af"])
+    ax.set_ylabel("Replays")
+    ax.set_title("Did the game truly end? (game_ended at last recorded tick)")
+    sections.append(f"<h2>Game end-state</h2>{img(fig, 'game ended breakdown')}")
+
+    # 9. Ranking initialization
+    fig, ax = plt.subplots(figsize=(5, 3.5))
+    ax.bar(["YES", "no", "unknown"], [rank_yes, rank_no, rank_unk], color=["#16a34a", "#dc2626", "#9ca3af"])
+    ax.set_ylabel("Replays")
+    ax.set_title("Was the ranking initialized? (newspaper_state.ranking.initialized)")
+    sections.append(f"<h2>Ranking initialization</h2>{img(fig, 'ranking initialized breakdown')}")
+
+    # 10. Player-count distribution
+    sections.append(hist_section(
+        "Player-count distribution",
+        "Players present at last recorded tick",
+        [x["player_count"] for x in rows if x["player_count"] is not None],
+        "#8b5cf6",
+    ))
+
+    # 11. Time-scale distribution
+    sections.append(hist_section(
+        "Time-scale distribution",
+        "Game time scale (in-game time per real-world time)",
+        [x["time_scale"] for x in rows if x["time_scale"] is not None],
+        "#0891b2",
+    ))
+
+    # 12. Typical sampling interval distribution
+    if with_intervals:
+        intervals_min = [x["typical_interval"].total_seconds() / 60.0 for x in with_intervals]
+        fig, ax = plt.subplots(figsize=(7, 4))
+        ax.hist(intervals_min, bins=min(30, max(5, len(intervals_min) // 2)), color="#2563eb", edgecolor="white")
+        ax.set_xlabel("Typical sampling interval (minutes, median Δ between recorded ticks)")
+        ax.set_ylabel("Replays")
+        ax.set_title("Distribution of typical sampling interval across replays")
+        sections.append(f"<h2>Typical sampling interval</h2>{img(fig, 'typical interval histogram')}")
+
+    # 13. Gap duration distribution (log-scale)
+    if all_gap_durations_min:
+        fig, ax = plt.subplots(figsize=(7, 4))
+        positive = [d for d in all_gap_durations_min if d > 0]
+        bins = np.logspace(np.log10(min(positive)), np.log10(max(positive)), 30)
+        ax.hist(positive, bins=bins, color="#dc2626", edgecolor="white")
+        ax.set_xscale("log")
+        ax.set_xlabel("Gap duration (minutes, log scale)")
+        ax.set_ylabel("Gaps")
+        ax.set_title(f"Distribution of individual gap durations (>{GAP_FACTOR}× the typical interval)")
+        sections.append(f"<h2>Gap duration distribution</h2>{img(fig, 'gap duration histogram')}")
+    else:
+        sections.append("<h2>Gap duration distribution</h2><p class='note'>No gaps detected in any replay.</p>")
+
+    # 14. Gap count / total time per replay (top N) + timeline
+    if with_gaps:
+        top_by_count = sorted(with_gaps, key=lambda x: x["gap_count"], reverse=True)[:top_n]
+        fig, ax = plt.subplots(figsize=(7, max(3, 0.32 * len(top_by_count))))
+        labels = [x["label"] for x in reversed(top_by_count)]
+        values = [x["gap_count"] for x in reversed(top_by_count)]
+        ax.barh(labels, values, color="#f59e0b")
+        ax.set_xlabel("Number of detected gaps")
+        ax.set_title(f"Top {len(top_by_count)} replays by gap count (game_id/player_id)")
+        sections.append(f"<h2>Replays with the most gaps</h2>{img(fig, 'gap count per replay')}")
+
+        top_by_total = sorted(with_gaps, key=lambda x: x["gap_total"], reverse=True)[:top_n]
+        fig, ax = plt.subplots(figsize=(7, max(3, 0.32 * len(top_by_total))))
+        labels = [x["label"] for x in reversed(top_by_total)]
+        values = [x["gap_total"].total_seconds() / 3600.0 for x in reversed(top_by_total)]
+        ax.barh(labels, values, color="#8b5cf6")
+        ax.set_xlabel("Total gap time (hours)")
+        ax.set_title(f"Top {len(top_by_total)} replays by total missing time (game_id/player_id)")
+        sections.append(f"<h2>Replays with the most missing time</h2>{img(fig, 'total gap time per replay')}")
+
+        timeline_candidates = [x for x in with_gaps if x["sog"] and x["eog"]]
+        timeline_rows = sorted(timeline_candidates, key=lambda x: x["gap_total"], reverse=True)[:top_n]
+        if timeline_rows:
+            fig, ax = plt.subplots(figsize=(9, max(3, 0.4 * len(timeline_rows))))
+            for i, x in enumerate(reversed(timeline_rows)):
+                sog, eog = x["sog"], x["eog"]
+                span_h = (eog - sog).total_seconds() / 3600.0
+                ax.barh(i, span_h, left=0, color="#bbf7d0", edgecolor="#16a34a", height=0.6, label="recorded span" if i == 0 else None)
+                for gap_start, gap_end, _ in x["gaps"]:
+                    g0 = (strip_tz(gap_start) - sog).total_seconds() / 3600.0
+                    g1 = (strip_tz(gap_end) - sog).total_seconds() / 3600.0
+                    ax.barh(i, g1 - g0, left=g0, color="#dc2626", height=0.6, label="gap" if i == 0 else None)
+            ax.set_yticks(range(len(timeline_rows)))
+            ax.set_yticklabels([x["label"] for x in reversed(timeline_rows)])
+            ax.set_xlabel("Hours since start_of_game")
+            ax.set_title(f"Gap timeline — top {len(timeline_rows)} replays by total missing time")
+            ax.legend(loc="upper right")
+            sections.append(
+                f"<h2>Where the gaps fall within each game</h2>"
+                f"<p class='note'>Green = total game span; red = detected recording gaps.</p>"
+                f"{img(fig, 'gap timeline gantt chart')}"
+            )
+
+    # 15. Datatype version distribution
+    version_counter: Counter = Counter()
+    incompatible_versions: set[int] = set()
+    for r in results:
+        version_counter.update(r.required_versions)
+        incompatible_versions.update(r.unsupported_versions)
+    if version_counter:
+        fig, ax = plt.subplots(figsize=(6, 3.5))
+        labels = [f"v{v}" for v in sorted(version_counter)]
+        values = [version_counter[v] for v in sorted(version_counter)]
+        colors = ["#dc2626" if v in incompatible_versions else "#2563eb" for v in sorted(version_counter)]
+        ax.bar(labels, values, color=colors)
+        ax.set_ylabel("Replays")
+        ax.set_title("Datatype version distribution (red = unsupported by this build)")
+        sections.append(f"<h2>Datatype versions</h2>{img(fig, 'datatype version distribution')}")
+
+    # 16. Province-count consistency
+    consistency = province_consistency(results)
+    if consistency:
+        table_rows = []
+        for map_id, info in sorted(consistency.items()):
+            counts = info["counts"]
+            expected_str = str(info["expected_count"]) if info["expected_count"] is not None else "?"
+            avg_c = sum(counts) / len(counts)
+            missing_replays = (
+                sum(1 for c in counts if c < info["expected_count"])
+                if info["expected_count"] is not None else "?"
+            )
+            table_rows.append(
+                f"<tr><td>{map_id}</td><td>{info['n_games']}</td><td>{expected_str}</td>"
+                f"<td>{avg_c:.1f}</td><td>{min(counts)}</td><td>{max(counts)}</td>"
+                f"<td>{missing_replays}</td></tr>"
+            )
+        table_html = (
+            "<table><tr><th>map_id</th><th>replays</th><th>expected provinces</th>"
+            "<th>avg actual</th><th>min</th><th>max</th><th>replays missing ≥1 province</th></tr>"
+            + "".join(table_rows) + "</table>"
+        )
+        sections.append(f"<h2>Province-count consistency (per map)</h2>{table_html}")
+
+        global_missing: Counter = Counter()
+        for info in consistency.values():
+            global_missing.update(info["missing_counter"])
+        if global_missing:
+            top_missing = global_missing.most_common(top_n)
+            fig, ax = plt.subplots(figsize=(7, max(3, 0.32 * len(top_missing))))
+            labels = [str(pid) for pid, _ in reversed(top_missing)]
+            values = [n for _, n in reversed(top_missing)]
+            ax.barh(labels, values, color="#dc2626")
+            ax.set_xlabel("Number of replays missing this province")
+            ax.set_title(f"Top {len(top_missing)} most frequently missing provinces (province id)")
+            sections.append(f"<h2>Most frequently missing provinces</h2>{img(fig, 'missing provinces per replay')}")
+    else:
+        sections.append(
+            "<h2>Province-count consistency</h2>"
+            "<p class='note'>No static map data provided — skipped.</p>"
+        )
+
+    n_with_gaps = len(with_gaps)
+    avg_span_cov = sum(span_coverages) / len(span_coverages) if span_coverages else None
+    avg_cont_cov = sum(cont_coverages) / len(cont_coverages) if cont_coverages else None
+    metrics_html = (
+        "<div class='metrics'>"
+        f"<div class='metric'><div class='label'>Replays analysed</div><div class='value'>{len(results)}</div></div>"
+        f"<div class='metric'><div class='label'>OK</div><div class='value'>{status_counts.get(Status.OK, 0)}</div></div>"
+        f"<div class='metric'><div class='label'>Degraded</div><div class='value'>{status_counts.get(Status.DEGRADED, 0)}</div></div>"
+        f"<div class='metric'><div class='label'>Failed</div><div class='value'>{status_counts.get(Status.FAILED, 0)}</div></div>"
+        f"<div class='metric'><div class='label'>Avg span coverage</div><div class='value'>"
+        f"{f'{avg_span_cov:.1f}%' if avg_span_cov is not None else '?'}</div></div>"
+        f"<div class='metric'><div class='label'>Avg continuity coverage</div><div class='value'>"
+        f"{f'{avg_cont_cov:.1f}%' if avg_cont_cov is not None else '?'}</div></div>"
+        f"<div class='metric'><div class='label'>Replays with gaps</div><div class='value'>{n_with_gaps}/{len(full) or 1}</div></div>"
+        "</div>"
+    )
+
+    html = f"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Replay health report</title>
+<style>{_HEALTH_REPORT_CSS}</style>
+</head>
+<body>
+<h1>Replay health report</h1>
+<p class="note">
+An overview of the health of {len(results)} replays: overall status (OK/degraded/failed),
+why replays failed or were degraded, how much of each game was actually captured (span vs.
+gap-aware continuity coverage), player and ranking validity, and province-count consistency
+against static map data. A "gap" is a delta between two consecutive recorded in-game
+timestamps that is more than {GAP_FACTOR}× the replay's own typical (median) sampling
+interval — i.e. a point where recording silently paused and resumed later.
+</p>
+{metrics_html}
+{''.join(sections)}
+</body>
+</html>
+"""
+
+    output_path.write_text(html, encoding="utf-8")
+    print(f"\nReplay health report written to {output_path}", flush=True)

--- a/scripts/replay_healthcheck/report_json.py
+++ b/scripts/replay_healthcheck/report_json.py
@@ -1,0 +1,97 @@
+"""Machine-readable JSON export.
+
+Intended as the artifact a future automated filtering step (in
+game_stats_extractor or gnn_extractor) could consume to exclude low-quality
+replays from a corpus — no such integration is built here, only the export.
+"""
+
+import json
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from .aggregate import province_consistency
+from .models import ReplayHealth
+
+
+def _iso(dt: datetime | None) -> str | None:
+    return dt.isoformat() if dt is not None else None
+
+
+def _seconds(td: timedelta | None) -> float | None:
+    return td.total_seconds() if td is not None else None
+
+
+def _replay_to_dict(r: ReplayHealth) -> dict:
+    return {
+        "game_id": r.game_id,
+        "player_id": r.player_id,
+        "name": r.name,
+        "status": r.status.value,
+        "failure_category": r.failure_category.value if r.failure_category else None,
+        "failure_detail": r.failure_detail,
+        "parse_depth": r.parse_depth,
+        "degraded_reasons": r.degraded_reasons,
+        "segment_count": r.segment_count,
+        "patches": r.patches,
+        "map_id": r.map_id,
+        "seg_first_ts": _iso(r.seg_first_ts),
+        "seg_last_ts": _iso(r.seg_last_ts),
+        "required_versions": sorted(r.required_versions),
+        "unsupported_versions": sorted(r.unsupported_versions),
+        "start_of_game": _iso(r.start_of_game),
+        "end_of_game": _iso(r.end_of_game),
+        "day_first": r.day_first,
+        "day_last": r.day_last,
+        "time_scale": r.time_scale,
+        "game_ended": r.game_ended,
+        "ranking_initialized": r.ranking_initialized,
+        "province_count": len(r.province_ids) if r.province_ids is not None else None,
+        "expected_province_count": len(r.expected_province_ids) if r.expected_province_ids is not None else None,
+        "missing_province_ids": (
+            sorted(r.expected_province_ids - r.province_ids)
+            if r.expected_province_ids is not None and r.province_ids is not None
+            else None
+        ),
+        "player_count": r.player_count,
+        "real_player_count": r.real_player_count,
+        "has_real_players": r.has_real_players,
+        "invalid_activity_state_count": r.invalid_activity_state_count,
+        "n_timestamps": r.n_timestamps,
+        "typical_interval_seconds": _seconds(r.typical_interval),
+        "gap_count": r.gap_count,
+        "gap_total_seconds": _seconds(r.gap_total),
+        "covered_seconds": r.covered_seconds,
+    }
+
+
+def write_json_report(results: list[ReplayHealth], output_path: Path, replays_dir: Path) -> None:
+    status_counts = Counter(r.status.value for r in results)
+    failure_counts = Counter(r.failure_category.value for r in results if r.failure_category)
+    reason_counts: Counter = Counter()
+    for r in results:
+        reason_counts.update(r.degraded_reasons)
+
+    payload = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "replays_dir": str(replays_dir),
+        "summary": {
+            "total": len(results),
+            "status_counts": dict(status_counts),
+            "failure_category_counts": dict(failure_counts),
+            "degraded_reason_counts": dict(reason_counts),
+            "province_consistency": {
+                map_id: {
+                    "n_games": info["n_games"],
+                    "expected_count": info["expected_count"],
+                    "min_actual": min(info["counts"]),
+                    "max_actual": max(info["counts"]),
+                }
+                for map_id, info in province_consistency(results).items()
+            },
+        },
+        "replays": [_replay_to_dict(r) for r in results],
+    }
+
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"Replay health JSON export written to {output_path}", flush=True)

--- a/scripts/replay_healthcheck/report_text.py
+++ b/scripts/replay_healthcheck/report_text.py
@@ -1,0 +1,277 @@
+"""Terminal report."""
+
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+
+from .aggregate import province_consistency
+from .analyze import GAP_FACTOR
+from .models import ReplayHealth, Status
+
+SEP = "=" * 140
+SUBSEP = "-" * 140
+
+
+def strip_tz(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if hasattr(dt, "tzinfo") and dt.tzinfo is not None:
+        return dt.astimezone(UTC).replace(tzinfo=None)
+    return dt
+
+
+def fmt_td(td: timedelta | None, *, unit: str = "h") -> str:
+    if td is None:
+        return "?"
+    total_s = td.total_seconds()
+    sign = "-" if total_s < 0 else ""
+    total_s = abs(total_s)
+    if unit == "h":
+        h = int(total_s // 3600)
+        m = int((total_s % 3600) // 60)
+        return f"{sign}{h}h{m:02d}m"
+    if unit == "d":
+        d = int(total_s // 86400)
+        h = int((total_s % 86400) // 3600)
+        return f"{sign}{d}d{h:02d}h"
+    return f"{sign}{total_s:.0f}s"
+
+
+def _avg_td(tds: list[timedelta]) -> timedelta:
+    return timedelta(seconds=sum(t.total_seconds() for t in tds) / len(tds))
+
+
+def print_report(results: list[ReplayHealth]) -> None:
+    print(f"\n{SEP}")
+    print(f"REPLAY HEALTH CHECK  —  {len(results)} replays")
+    print(SEP)
+
+    # ── Status breakdown ──────────────────────────────────────────────────
+    status_counts = Counter(r.status for r in results)
+    print("\nSTATUS")
+    print(SUBSEP)
+    for status in (Status.OK, Status.DEGRADED, Status.FAILED):
+        print(f"  {status.value:<9} {status_counts.get(status, 0)}/{len(results)}")
+
+    metadata_only_ok = sum(
+        1 for r in results if r.parse_depth == "metadata_only" and r.status == Status.OK
+    )
+    if metadata_only_ok:
+        print(
+            f"\n  Note: {metadata_only_ok} replay(s) only reached metadata_only depth "
+            f"(no static map data available for their map_id) — their OK status reflects "
+            f"only file-integrity and version checks, not game-content quality."
+        )
+
+    failed = [r for r in results if r.status == Status.FAILED]
+    if failed:
+        print("\nFAILURE CATEGORIES (among FAILED)")
+        print(SUBSEP)
+        cat_counts = Counter(r.failure_category for r in failed)
+        for cat, n in cat_counts.most_common():
+            print(f"  {cat.value:<32} {n}")
+
+    degraded = [r for r in results if r.status == Status.DEGRADED]
+    if degraded:
+        print("\nDEGRADED REASONS (not mutually exclusive)")
+        print(SUBSEP)
+        reason_counts: Counter = Counter()
+        for r in degraded:
+            reason_counts.update(r.degraded_reasons)
+        for reason, n in reason_counts.most_common():
+            print(f"  {reason:<32} {n}/{len(degraded)}")
+
+    # ── Per-replay table ──────────────────────────────────────────────────
+    hdr = (
+        f"{'game_id':>10}  {'player':>6}  {'status':>9}  {'patches':>7}  "
+        f"{'time_scale':>10}  {'lag_into_game':>13}  "
+        f"{'ingame_dur':>10}  {'span_cov%':>9}  {'cont_cov%':>9}  {'gaps':>9}  "
+        f"{'days':>6}  {'ended?':>7}  {'rank_init':>9}"
+    )
+    print(f"\n{hdr}")
+    print(SUBSEP)
+
+    full = [r for r in results if r.parse_depth == "full"]
+    ingame_durations: list[timedelta] = []
+    span_coverages: list[float] = []
+    cont_coverages: list[float] = []
+    lags: list[timedelta] = []
+    gap_counts: list[int] = []
+    gap_totals: list[timedelta] = []
+    ended_yes = ended_no = ended_unk = 0
+    rank_yes = rank_no = rank_unk = 0
+
+    for r in results:
+        ft = strip_tz(r.seg_first_ts)
+        lt = strip_tz(r.seg_last_ts)
+        ingame_dur = (lt - ft) if ft and lt else None
+        sog = strip_tz(r.start_of_game)
+        eog = strip_tz(r.end_of_game)
+        total_game_span = (eog - sog) if sog and eog else None
+        span_cov_pct = (
+            ingame_dur.total_seconds() / total_game_span.total_seconds() * 100
+            if ingame_dur and total_game_span and total_game_span.total_seconds() > 0
+            else None
+        )
+        cont_cov_pct = (
+            r.covered_seconds / total_game_span.total_seconds() * 100
+            if r.covered_seconds is not None and total_game_span and total_game_span.total_seconds() > 0
+            else None
+        )
+        lag = (ft - sog) if ft and sog else None
+        d0, d1 = r.day_first, r.day_last
+        days_str = f"{d0}→{d1}" if d0 is not None and d1 is not None else "?"
+
+        if r.parse_depth == "full":
+            ended = r.game_ended
+            if ended is True:
+                ended_str = "YES"
+                ended_yes += 1
+            elif ended is False:
+                ended_str = "no"
+                ended_no += 1
+            else:
+                ended_str = "?"
+                ended_unk += 1
+
+            rank_init = r.ranking_initialized
+            if rank_init is True:
+                rank_init_str = "YES"
+                rank_yes += 1
+            elif rank_init is False:
+                rank_init_str = "no"
+                rank_no += 1
+            else:
+                rank_init_str = "?"
+                rank_unk += 1
+
+            if ingame_dur:
+                ingame_durations.append(ingame_dur)
+            if span_cov_pct is not None:
+                span_coverages.append(span_cov_pct)
+            if cont_cov_pct is not None:
+                cont_coverages.append(cont_cov_pct)
+            if lag is not None:
+                lags.append(lag)
+            if r.n_timestamps is not None:
+                gap_counts.append(r.gap_count)
+                gap_totals.append(r.gap_total)
+        else:
+            ended_str = "?"
+            rank_init_str = "?"
+
+        ts_str = f"{r.time_scale:.2f}" if r.time_scale is not None else "?"
+        span_cov_str = f"{span_cov_pct:.1f}%" if span_cov_pct is not None else "?"
+        cont_cov_str = f"{cont_cov_pct:.1f}%" if cont_cov_pct is not None else "?"
+        gaps_str = (
+            f"{r.gap_count} ({fmt_td(r.gap_total)})" if r.n_timestamps is not None else "?"
+        )
+        print(
+            f"{(r.game_id if r.game_id is not None else '?'):>10}  "
+            f"{(r.player_id if r.player_id is not None else '?'):>6}  "
+            f"{r.status.value:>9}  {(r.patches or 0):>7}  "
+            f"{ts_str:>10}  "
+            f"{fmt_td(lag):>13}  {fmt_td(ingame_dur, unit='d'):>10}  "
+            f"{span_cov_str:>9}  {cont_cov_str:>9}  {gaps_str:>9}  "
+            f"{days_str:>6}  {ended_str:>7}  {rank_init_str:>9}"
+        )
+
+    print(f"\n{SEP}")
+    print("SUMMARY (over fully-parsed replays only)")
+    print(SEP)
+
+    if ingame_durations:
+        print("\nIn-game time span recorded (seg_last − seg_first, game-universe time):")
+        print(f"  avg {fmt_td(_avg_td(ingame_durations), unit='d')}   "
+              f"min {fmt_td(min(ingame_durations), unit='d')}   "
+              f"max {fmt_td(max(ingame_durations), unit='d')}")
+
+    if lags:
+        print("\nLag — how far into the game recording started (game-universe time):")
+        print(f"  avg {fmt_td(_avg_td(lags))}   min {fmt_td(min(lags))}   max {fmt_td(max(lags))}")
+
+    if span_coverages:
+        avg_cov = sum(span_coverages) / len(span_coverages)
+        print("\nSpan coverage (recorded first→last in-game span / total game span):")
+        print(f"  avg {avg_cov:.1f}%   min {min(span_coverages):.1f}%   max {max(span_coverages):.1f}%")
+        print(f"  ({len(span_coverages)} replays had end_of_game; others excluded)")
+
+    if cont_coverages:
+        avg_cov = sum(cont_coverages) / len(cont_coverages)
+        print(f"\nContinuity coverage (gaps > {GAP_FACTOR}x the typical sampling interval excluded):")
+        print(f"  avg {avg_cov:.1f}%   min {min(cont_coverages):.1f}%   max {max(cont_coverages):.1f}%")
+        print(f"  ({len(cont_coverages)} replays had end_of_game; others excluded)")
+
+    if gap_counts:
+        with_gaps = sum(1 for c in gap_counts if c > 0)
+        print("\nRecording gaps:")
+        print(f"  {with_gaps}/{len(gap_counts)} replays had at least one gap   "
+              f"avg {sum(gap_counts) / len(gap_counts):.1f} gaps/replay   max {max(gap_counts)} gaps")
+        print(f"  total gap time — avg {fmt_td(_avg_td(gap_totals), unit='d')}   "
+              f"max {fmt_td(max(gap_totals), unit='d')}")
+
+    if full:
+        print("\nDid the game truly end? (game_ended flag at last recorded tick):")
+        print(f"  YES: {ended_yes}   no: {ended_no}   unknown/error: {ended_unk}")
+
+        print("\nWas the ranking initialized? (newspaper_state.ranking.initialized at last recorded tick):")
+        print(f"  YES: {rank_yes}   no: {rank_no}   unknown/error: {rank_unk}")
+
+    # ── Player validation ───────────────────────────────────────────────────
+    player_counts = [r.player_count for r in full if r.player_count is not None]
+    if player_counts:
+        no_real_players = sum(1 for r in full if r.has_real_players is False)
+        invalid_activity = sum(1 for r in full if (r.invalid_activity_state_count or 0) > 0)
+        print("\nPLAYER VALIDATION")
+        print(SUBSEP)
+        print(f"  player count — avg {sum(player_counts) / len(player_counts):.1f}   "
+              f"min {min(player_counts)}   max {max(player_counts)}")
+        print(f"  replays with no real players (all AI/terrorist): {no_real_players}/{len(full)}")
+        print(f"  replays with an invalid player activity_state: {invalid_activity}/{len(full)}")
+
+    # ── Datatype version distribution ──────────────────────────────────────
+    version_counter: Counter = Counter()
+    for r in results:
+        version_counter.update(r.required_versions)
+    if version_counter:
+        print("\nDATATYPE VERSION DISTRIBUTION")
+        print(SUBSEP)
+        for version, n in sorted(version_counter.items()):
+            incompatible = any(version in r.unsupported_versions for r in results)
+            flag = "  (UNSUPPORTED by this build)" if incompatible else ""
+            print(f"  v{version}: {n} replay(s){flag}")
+
+    # ── Segment count (recording-restart indicator) ─────────────────────────
+    segment_counts = [r.segment_count for r in results if r.segment_count is not None]
+    if segment_counts:
+        multi_segment = sum(1 for c in segment_counts if c > 1)
+        print("\nSEGMENT COUNT (recording restarts)")
+        print(SUBSEP)
+        print(f"  avg {sum(segment_counts) / len(segment_counts):.1f}   "
+              f"min {min(segment_counts)}   max {max(segment_counts)}   "
+              f"replays with >1 segment: {multi_segment}/{len(segment_counts)}")
+
+    # ── Province-count consistency ───────────────────────────────────────────
+    consistency = province_consistency(results)
+    print(f"\n{SEP}")
+    print("PROVINCE-COUNT CONSISTENCY (per map_id)")
+    print(SEP)
+    if consistency:
+        for map_id, info in sorted(consistency.items()):
+            counts = info["counts"]
+            expected_str = str(info["expected_count"]) if info["expected_count"] is not None else "?"
+            print(f"\nmap_id {map_id}  ({info['n_games']} replay(s))")
+            print(f"  expected provinces (static map data): {expected_str}")
+            print(f"  actual province count — avg {sum(counts) / len(counts):.1f}   "
+                  f"min {min(counts)}   max {max(counts)}")
+            if info["expected_count"] is not None:
+                games_missing = sum(1 for c in counts if c < info["expected_count"])
+                print(f"  replays missing at least one province: {games_missing}/{info['n_games']}")
+                if info["missing_counter"]:
+                    top_missing = info["missing_counter"].most_common(10)
+                    missing_str = ", ".join(f"{pid} ({n}/{info['n_games']})" for pid, n in top_missing)
+                    print(f"  most frequently missing province ids: {missing_str}")
+                else:
+                    print("  no missing provinces detected — all replays on this map have the full expected set")
+    else:
+        print("\nNo static map data available — province-count consistency skipped.")
+    print()

--- a/tools/game_stats_extractor/pyproject.toml
+++ b/tools/game_stats_extractor/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "conflict-interface>=0.1.2",
     "pydantic>=2.0",
     "tqdm",
+    "numpy",
+    "scikit-learn",
 ]
 
 [project.scripts]

--- a/tools/game_stats_extractor/src/game_stats_extractor/aggregators/country_aggregator.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/aggregators/country_aggregator.py
@@ -125,6 +125,7 @@ def _aggregate_country(
     return CountryAggregate(
         nation_name=nation_name,
         games_played=games_played,
+        human_games_played=human_n,
         wins=wins,
         win_rate=wins / games_played,
         avg_final_vp=_mean(final_vps),

--- a/tools/game_stats_extractor/src/game_stats_extractor/aggregators/global_aggregator.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/aggregators/global_aggregator.py
@@ -96,13 +96,13 @@ class GlobalAggregator(BaseAggregator[GlobalAggregate]):
         top_pairs = sorted(pair_counts.items(), key=lambda x: x[1], reverse=True)[:20]
         top_coalition_pairs = [[a, b, cnt] for (a, b), cnt in top_pairs]
 
-        # Elimination timing distribution — 10% game buckets, human players only
+        # Elimination timing distribution — 10 game-day buckets, human players only
         elim_dist: dict[str, int] = {}
         for g in games:
             for p in g.players:
-                if p.is_ai or not p.is_defeated or p.elimination_game_pct is None:
+                if p.is_ai or not p.is_defeated or p.elimination_game_day is None:
                     continue
-                bucket = str(int(p.elimination_game_pct // 10) * 10)
+                bucket = str(int(p.elimination_game_day // 10) * 10)
                 elim_dist[bucket] = elim_dist.get(bucket, 0) + 1
 
         # Traitor wins — solo wins where the winner left a >=2-member coalition shortly before winning

--- a/tools/game_stats_extractor/src/game_stats_extractor/aggregators/global_aggregator.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/aggregators/global_aggregator.py
@@ -105,6 +105,11 @@ class GlobalAggregator(BaseAggregator[GlobalAggregate]):
                 bucket = str(int(p.elimination_game_pct // 10) * 10)
                 elim_dist[bucket] = elim_dist.get(bucket, 0) + 1
 
+        # Traitor wins — solo wins where the winner left a >=2-member coalition shortly before winning
+        solo_games = sum(1 for g in games if g.victory_type == "solo")
+        total_traitor_wins = sum(1 for g in games if g.traitor_ids)
+        traitor_win_rate = total_traitor_wins / solo_games if solo_games > 0 else 0.0
+
         return GlobalAggregate(
             total_games=len(games),
             avg_duration_hours=statistics.mean(durations),
@@ -127,6 +132,8 @@ class GlobalAggregator(BaseAggregator[GlobalAggregate]):
             avg_coalition_size=statistics.mean(coalition_sizes) if coalition_sizes else 0.0,
             top_coalition_pairs=top_coalition_pairs,
             elimination_timing_distribution=elim_dist,
+            total_traitor_wins=total_traitor_wins,
+            traitor_win_rate=traitor_win_rate,
         )
 
 

--- a/tools/game_stats_extractor/src/game_stats_extractor/aggregators/nation_similarity_aggregator.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/aggregators/nation_similarity_aggregator.py
@@ -1,0 +1,102 @@
+"""Section 2.2b — clusters nations by build style (normalized building composition).
+
+Restricted to nations with enough human-played games to stand in for the roster of
+player-controlled nations, since the replay data has no explicit "is playable" flag.
+"""
+import numpy as np
+from sklearn.cluster import KMeans
+from sklearn.decomposition import PCA
+from sklearn.metrics import silhouette_score
+from sklearn.preprocessing import StandardScaler
+
+from ..models.aggregates import ClusterInfo, CountryAggregate, NationSimilarityAggregate
+
+MIN_HUMAN_GAMES = 5
+MIN_K, MAX_K = 3, 10
+TOP_N_BUILDINGS = 3
+
+
+class NationSimilarityAggregator:
+    """Takes CountryAggregate output (not raw GameData) — building composition is
+    already aggregated per nation by CountryAggregator."""
+
+    def aggregate(
+        self, country_aggs: list[CountryAggregate]
+    ) -> tuple[list[NationSimilarityAggregate], list[ClusterInfo]]:
+        nations = [c for c in country_aggs if c.human_games_played >= MIN_HUMAN_GAMES]
+        if len(nations) < MIN_K + 1:
+            return [], []
+
+        building_ids = sorted({uid for c in nations for uid in c.avg_final_building_counts})
+        if not building_ids:
+            return [], []
+
+        # Row-normalize each nation's building counts to proportions of its own total,
+        # so build *style* is compared rather than raw build volume.
+        raw = np.array(
+            [[c.avg_final_building_counts.get(uid, 0.0) for uid in building_ids] for c in nations]
+        )
+        totals = raw.sum(axis=1, keepdims=True)
+        proportions = np.divide(raw, totals, out=np.zeros_like(raw), where=totals > 0)
+
+        scaled = StandardScaler().fit_transform(proportions)
+
+        pca_coords = PCA(n_components=2, random_state=0).fit_transform(scaled)
+
+        cluster_ids = _best_kmeans(scaled)
+
+        pop_mean = proportions.mean(axis=0)
+        pop_std = proportions.std(axis=0)
+        pop_std[pop_std == 0] = 1.0
+
+        nation_results: list[NationSimilarityAggregate] = []
+        for i, c in enumerate(nations):
+            z_scores = (proportions[i] - pop_mean) / pop_std
+            top_idx = np.argsort(z_scores)[::-1][:TOP_N_BUILDINGS]
+            nation_results.append(
+                NationSimilarityAggregate(
+                    nation_name=c.nation_name,
+                    games_played=c.games_played,
+                    human_games_played=c.human_games_played,
+                    cluster_id=int(cluster_ids[i]),
+                    pca_x=round(float(pca_coords[i, 0]), 4),
+                    pca_y=round(float(pca_coords[i, 1]), 4),
+                    top_buildings=[building_ids[j] for j in top_idx],
+                )
+            )
+
+        clusters: list[ClusterInfo] = []
+        for k in sorted(set(cluster_ids.tolist())):
+            members = cluster_ids == k
+            centroid = proportions[members].mean(axis=0)
+            centroid_z = (centroid - pop_mean) / pop_std
+            top_idx = np.argsort(centroid_z)[::-1][:TOP_N_BUILDINGS]
+            top_buildings = [building_ids[j] for j in top_idx]
+            clusters.append(
+                ClusterInfo(
+                    id=int(k),
+                    label=" / ".join(top_buildings[:2]),
+                    size=int(members.sum()),
+                    top_buildings=top_buildings,
+                )
+            )
+
+        return nation_results, clusters
+
+
+def _best_kmeans(scaled: np.ndarray) -> np.ndarray:
+    n = scaled.shape[0]
+    best_labels = None
+    best_score = -1.0
+    max_k = min(MAX_K, n - 1)
+    for k in range(MIN_K, max_k + 1):
+        labels = KMeans(n_clusters=k, n_init=10, random_state=0).fit_predict(scaled)
+        if len(set(labels)) < 2:
+            continue
+        score = silhouette_score(scaled, labels)
+        if score > best_score:
+            best_score = score
+            best_labels = labels
+    if best_labels is None:
+        best_labels = KMeans(n_clusters=MIN_K, n_init=10, random_state=0).fit_predict(scaled)
+    return best_labels

--- a/tools/game_stats_extractor/src/game_stats_extractor/aggregators/province_aggregator.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/aggregators/province_aggregator.py
@@ -48,6 +48,11 @@ def _aggregate_province(
 
     is_coastal = sum(1 for _, p in entries if p.is_coastal) > games_appeared / 2
 
+    region_counts: dict[str, int] = defaultdict(int)
+    for _, p in entries:
+        region_counts[p.region] += 1
+    region = max(region_counts, key=lambda k: region_counts[k])
+
     ownership_changes = [p.ownership_changes for _, p in entries]
     avg_ownership_changes = statistics.mean(ownership_changes)
     contest_frequency = sum(1 for c in ownership_changes if c > 0) / games_appeared
@@ -86,6 +91,7 @@ def _aggregate_province(
         province_name=province_name,
         terrain_type=terrain_type,
         is_coastal=is_coastal,
+        region=region,
         games_appeared=games_appeared,
         avg_ownership_changes=avg_ownership_changes,
         contest_frequency=contest_frequency,

--- a/tools/game_stats_extractor/src/game_stats_extractor/aggregators/province_aggregator.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/aggregators/province_aggregator.py
@@ -53,6 +53,20 @@ def _aggregate_province(
         region_counts[p.region] += 1
     region = max(region_counts, key=lambda k: region_counts[k])
 
+    # Original (legal/home) owner nation — resolve each game's legal_owner_id
+    # (a per-game player slot) to that game's nation name, then take the mode.
+    owner_nation_counts: dict[str, int] = defaultdict(int)
+    for game, p in entries:
+        if p.legal_owner_id < 0:
+            continue
+        for player in game.players:
+            if player.player_id == p.legal_owner_id:
+                owner_nation_counts[player.nation_name] += 1
+                break
+    original_owner_nation = (
+        max(owner_nation_counts, key=lambda k: owner_nation_counts[k]) if owner_nation_counts else None
+    )
+
     ownership_changes = [p.ownership_changes for _, p in entries]
     avg_ownership_changes = statistics.mean(ownership_changes)
     contest_frequency = sum(1 for c in ownership_changes if c > 0) / games_appeared
@@ -92,6 +106,7 @@ def _aggregate_province(
         terrain_type=terrain_type,
         is_coastal=is_coastal,
         region=region,
+        original_owner_nation=original_owner_nation,
         games_appeared=games_appeared,
         avg_ownership_changes=avg_ownership_changes,
         contest_frequency=contest_frequency,

--- a/tools/game_stats_extractor/src/game_stats_extractor/extractors/replay_extractor.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/extractors/replay_extractor.py
@@ -204,7 +204,10 @@ class ReplayExtractor(BaseExtractor):
         # `region` is static per-map data. The live per-game province objects never
         # carry it (always None), so it has to come from the static map data
         # (locations, keyed by province id) supplied via --map-data-dir.
+        # `legal_owner` is likewise static per-map data — the province's home/core
+        # owner regardless of who currently occupies it via conquest.
         region_by_pid: dict[int, str] = {}
+        legal_owner_by_pid: dict[int, int] = {}
         static_map_data = getattr(map_obj, "static_map_data", None)
         if static_map_data is not None:
             for loc in static_map_data.locations:
@@ -212,6 +215,9 @@ class ReplayExtractor(BaseExtractor):
                 loc_id = getattr(loc, "id", None)
                 if loc_id is not None and loc_region and hasattr(loc_region[0], "name"):
                     region_by_pid[loc_id] = str(loc_region[0].name)
+                loc_legal_owner = getattr(loc, "legal_owner", None)
+                if loc_id is not None and loc_legal_owner is not None:
+                    legal_owner_by_pid[loc_id] = int(loc_legal_owner)
 
         # Province static info (name, terrain, coastal) — read once
         province_meta: dict[int, dict] = {
@@ -229,6 +235,7 @@ class ReplayExtractor(BaseExtractor):
                     if p.resource_production_type and hasattr(p.resource_production_type, "name")
                     else (str(p.resource_production_type) if p.resource_production_type else None)
                 ),
+                "legal_owner_id": legal_owner_by_pid.get(pid, getattr(p, "legal_owner", -1)),
             }
             for pid, p in initial_land.items()
         }
@@ -897,6 +904,7 @@ class ReplayExtractor(BaseExtractor):
                 region=pmeta["region"],
                 initial_owner_id=initial_owners.get(pid, -1),
                 final_owner_id=current_owners.get(pid, -1),
+                legal_owner_id=pmeta["legal_owner_id"],
                 ownership_changes=ownership_changes.get(pid, 0),
                 resource_production_type=pmeta["resource_production_type"],
                 resource_production=int(final_p.resource_production or 0) if final_p else 0,

--- a/tools/game_stats_extractor/src/game_stats_extractor/extractors/replay_extractor.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/extractors/replay_extractor.py
@@ -32,6 +32,14 @@ _TRAITOR_WINDOW_DAYS = 3
 # have costs yet produce no persistent building that we want to count.
 _NON_BUILDING_NAMES = frozenset({"Annex City", "Relocate Headquarters", "Nationalize"})
 
+# Victory-point multipliers by coalition size, i.e. a coalition of n players needs
+# victory_points_modifier * _VICTORY_POINTS_FACTORS[n] combined VP to win. This mirrors
+# the game's own ultshared.modding.configuration.UltTeamConfig.victoryPointsFactors table
+# (confirmed against real in-game values for n=1..5); it is a fixed design table, not a
+# formula, and the game caps coalitions at maxCoalitionSize=5. Sizes beyond 5 fall through
+# to the relative-VP fallback below.
+_VICTORY_POINTS_FACTORS = {1: 1.0, 2: 1.6, 3: 2.3, 4: 2.9, 5: 3.2}
+
 
 def _is_land_province(province) -> bool:
     """True for LandProvince objects (which have owner_id / morale)."""
@@ -852,7 +860,9 @@ class ReplayExtractor(BaseExtractor):
 
         # ---- Victory detection ----
         ranking = gs.states.newspaper_state.ranking
-        winner_ids, victory_type = _determine_winners(players, ranking)
+        game_info = gs.states.game_info_state
+        victory_points_modifier = (game_info.victory_points_modifier or 0) if game_info else 0
+        winner_ids, victory_type = _determine_winners(players, ranking, victory_points_modifier)
 
         # ---- Traitor detection — solo winner who left a coalition shortly before winning ----
         traitor_ids = [
@@ -923,7 +933,11 @@ class ReplayExtractor(BaseExtractor):
         )
 
 
-def _determine_winners(players: list[PlayerData], ranking=None) -> tuple[list[int], str]:
+def _determine_winners(
+    players: list[PlayerData],
+    ranking=None,
+    victory_points_modifier: int = 0,
+) -> tuple[list[int], str]:
     if not players:
         return [], "unknown"
 
@@ -948,6 +962,30 @@ def _determine_winners(players: list[PlayerData], ranking=None) -> tuple[list[in
             return [p.player_id for p in still_playing], "coalition"
 
     pool = still_playing or [p for p in players if not p.is_defeated] or players
+
+    # Real victory-point thresholds: a single player reaching victory_points_modifier VP
+    # wins solo; otherwise a team whose combined VP clears its size-scaled threshold wins.
+    if victory_points_modifier > 0:
+        solo_candidates = [p for p in pool if p.final_vp >= victory_points_modifier]
+        if solo_candidates:
+            top = max(solo_candidates, key=lambda p: p.final_vp)
+            return [top.player_id], "solo"
+
+        teams: dict[int, list[PlayerData]] = defaultdict(list)
+        for p in pool:
+            if p.team_id > 0:
+                teams[p.team_id].append(p)
+
+        for members in teams.values():
+            factor = _VICTORY_POINTS_FACTORS.get(len(members))
+            if factor is None:
+                continue  # coalition bigger than the known table — falls through below
+            if sum(p.final_vp for p in members) >= victory_points_modifier * factor:
+                return [p.player_id for p in members], "coalition"
+
+    # Nobody met a real threshold — either victory_points_modifier is unknown, or the
+    # coalition is bigger than the known table covers, or the game was ended by admin/vote
+    # with no clear winner. Guess from relative standing as a last resort.
     max_vp = max((p.final_vp for p in pool), default=0)
     if max_vp <= 0:
         return [], "unknown"

--- a/tools/game_stats_extractor/src/game_stats_extractor/extractors/replay_extractor.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/extractors/replay_extractor.py
@@ -23,6 +23,10 @@ logger = logging.getLogger(__name__)
 
 _UNOWNED = 0
 
+# A solo winner who left a coalition with >=2 remaining members within this many
+# in-game days of the game ending counts as a "traitor" win.
+_TRAITOR_WINDOW_DAYS = 3
+
 # One-time actions and game-managed upgrades that should not appear in building statistics.
 # Programmatic rule: only upgrades with non-empty costs are player-buildable; but these actions
 # have costs yet produce no persistent building that we want to count.
@@ -195,6 +199,11 @@ class ReplayExtractor(BaseExtractor):
                 "name": p.name,
                 "terrain_type": str(p.terrain_type.name) if hasattr(p.terrain_type, "name") else str(p.terrain_type),
                 "is_coastal": bool(getattr(p, "costal", False)),
+                "region": (
+                    str(p.region[0].name)
+                    if getattr(p, "region", None) and hasattr(p.region[0], "name")
+                    else "NONE"
+                ),
                 "resource_production_type": (
                     str(p.resource_production_type.name)
                     if p.resource_production_type and hasattr(p.resource_production_type, "name")
@@ -382,9 +391,20 @@ class ReplayExtractor(BaseExtractor):
         player_elimination_pct: dict[int, float] = {}
         player_elimination_day: dict[int, int] = {}
 
+        # Coalition (team_id) membership tracking — team_id is dynamic within a game
+        # (players can join/leave), unlike the per-player fields above which are static
+        # or monotonic. team_members seeds from the initial snapshot and is kept in sync
+        # on every team_id change so we can tell whether a departing player left behind
+        # a still-active coalition (>=2 members) vs. a team that simply dissolved.
+        team_members: dict[int, set[int]] = defaultdict(set)
+        for _pid, _profile in initial_players_map.items():
+            if _pid > _UNOWNED and _profile.team_id > 0:
+                team_members[_profile.team_id].add(_pid)
+        player_last_departure_day: dict[int, int] = {}
+
         # ---- Register hooks — only changed provinces/relations fire events ----
         replay.register_province_trigger(["owner_id", "morale", "resource_production", "money_production", "upgrades_set"])
-        replay.register_player_trigger(["victory_points", "defeated", "computer_player"])
+        replay.register_player_trigger(["victory_points", "defeated", "computer_player", "team_id"])
         replay.register_foreign_affairs_trigger()
 
         # ---- Iterate all timestamps ----
@@ -579,6 +599,17 @@ class ReplayExtractor(BaseExtractor):
                     _, new_cp = player_event.attributes["computer_player"]
                     if new_cp is not None:
                         is_computer_player[pid] = bool(new_cp)
+                if "team_id" in player_event.attributes:
+                    old_team, new_team = player_event.attributes["team_id"]
+                    if old_team is not None and new_team is not None and old_team != new_team:
+                        if old_team > 0 and len(team_members.get(old_team, ())) >= 2:
+                            et = replay.current_time
+                            if et is not None:
+                                elapsed = (et - start_time).total_seconds()
+                                player_last_departure_day[pid] = _day_bucket(elapsed, total_duration_seconds, game_days)
+                        team_members[old_team].discard(pid)
+                        if new_team > 0:
+                            team_members[new_team].add(pid)
 
             # Snapshot player territory counts and VP — O(players), not O(provinces)
             ct = replay.current_time
@@ -823,6 +854,14 @@ class ReplayExtractor(BaseExtractor):
         ranking = gs.states.newspaper_state.ranking
         winner_ids, victory_type = _determine_winners(players, ranking)
 
+        # ---- Traitor detection — solo winner who left a coalition shortly before winning ----
+        traitor_ids = [
+            wid for wid in winner_ids
+            if victory_type == "solo"
+            and wid in player_last_departure_day
+            and (game_days - player_last_departure_day[wid]) <= _TRAITOR_WINDOW_DAYS
+        ]
+
         # ---- Provinces ----
         provinces: list[ProvinceData] = []
         for pid, pmeta in province_meta.items():
@@ -833,6 +872,7 @@ class ReplayExtractor(BaseExtractor):
                 province_name=pmeta["name"],
                 terrain_type=pmeta["terrain_type"],
                 is_coastal=pmeta["is_coastal"],
+                region=pmeta["region"],
                 initial_owner_id=initial_owners.get(pid, -1),
                 final_owner_id=current_owners.get(pid, -1),
                 ownership_changes=ownership_changes.get(pid, 0),
@@ -861,6 +901,7 @@ class ReplayExtractor(BaseExtractor):
             avg_update_interval_seconds=avg_update_interval_seconds,
             winner_ids=winner_ids,
             victory_type=victory_type,
+            traitor_ids=traitor_ids,
             game_ended=True,  # guaranteed by early exit in extract()
             players=players,
             provinces=provinces,

--- a/tools/game_stats_extractor/src/game_stats_extractor/extractors/replay_extractor.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/extractors/replay_extractor.py
@@ -201,6 +201,18 @@ class ReplayExtractor(BaseExtractor):
             if _is_land_province(p)
         }
 
+        # `region` is static per-map data. The live per-game province objects never
+        # carry it (always None), so it has to come from the static map data
+        # (locations, keyed by province id) supplied via --map-data-dir.
+        region_by_pid: dict[int, str] = {}
+        static_map_data = getattr(map_obj, "static_map_data", None)
+        if static_map_data is not None:
+            for loc in static_map_data.locations:
+                loc_region = getattr(loc, "region", None)
+                loc_id = getattr(loc, "id", None)
+                if loc_id is not None and loc_region and hasattr(loc_region[0], "name"):
+                    region_by_pid[loc_id] = str(loc_region[0].name)
+
         # Province static info (name, terrain, coastal) — read once
         province_meta: dict[int, dict] = {
             pid: {
@@ -210,7 +222,7 @@ class ReplayExtractor(BaseExtractor):
                 "region": (
                     str(p.region[0].name)
                     if getattr(p, "region", None) and hasattr(p.region[0], "name")
-                    else "NONE"
+                    else region_by_pid.get(pid, "NONE")
                 ),
                 "resource_production_type": (
                     str(p.resource_production_type.name)

--- a/tools/game_stats_extractor/src/game_stats_extractor/models/aggregates.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/models/aggregates.py
@@ -81,6 +81,7 @@ class CountryAggregate(BaseModel):
     avg_peace_treaties_signed: float = 0.0
     avg_alliances_formed: float = 0.0
     avg_right_of_ways_signed: float = 0.0
+    avg_shared_intelligence_signed: float = 0.0
     avg_total_production: dict[str, float] = {}
     avg_production_rate: dict[str, float] = {}
     avg_final_building_counts: dict[str, float] = {}

--- a/tools/game_stats_extractor/src/game_stats_extractor/models/aggregates.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/models/aggregates.py
@@ -65,6 +65,7 @@ class CountryAggregate(BaseModel):
     """Section 2.2 — per-country aggregate across all games where that country was played."""
     nation_name: str
     games_played: int
+    human_games_played: int = 0
     wins: int
     win_rate: float
     avg_final_vp: float
@@ -92,6 +93,26 @@ class CountryAggregate(BaseModel):
     coalition_win_rate: float = 0.0
     avg_winning_coalition_size: float = 0.0
     avg_elimination_pct: Optional[float] = None
+
+
+class ClusterInfo(BaseModel):
+    """A KMeans cluster over normalized nation building-composition vectors."""
+    id: int
+    label: str
+    size: int
+    top_buildings: list[str] = []
+
+
+class NationSimilarityAggregate(BaseModel):
+    """Section 2.2b — per-nation build-style clustering, restricted to nations with
+    enough human-played games to be meaningfully player-controlled."""
+    nation_name: str
+    games_played: int
+    human_games_played: int
+    cluster_id: int
+    pca_x: float
+    pca_y: float
+    top_buildings: list[str] = []
 
 
 class ProvinceAggregate(BaseModel):

--- a/tools/game_stats_extractor/src/game_stats_extractor/models/aggregates.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/models/aggregates.py
@@ -57,6 +57,8 @@ class GlobalAggregate(BaseModel):
     avg_coalition_size: float = 0.0
     top_coalition_pairs: list[list[str | int]] = []
     elimination_timing_distribution: dict[str, int] = {}
+    total_traitor_wins: int = 0
+    traitor_win_rate: float = 0.0
 
 
 class CountryAggregate(BaseModel):
@@ -97,6 +99,7 @@ class ProvinceAggregate(BaseModel):
     province_name: str
     terrain_type: str
     is_coastal: bool
+    region: str
     games_appeared: int
     avg_ownership_changes: float
     contest_frequency: float

--- a/tools/game_stats_extractor/src/game_stats_extractor/models/aggregates.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/models/aggregates.py
@@ -101,6 +101,7 @@ class ProvinceAggregate(BaseModel):
     terrain_type: str
     is_coastal: bool
     region: str
+    original_owner_nation: Optional[str] = None
     games_appeared: int
     avg_ownership_changes: float
     contest_frequency: float

--- a/tools/game_stats_extractor/src/game_stats_extractor/models/intermediate.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/models/intermediate.py
@@ -64,6 +64,7 @@ class ProvinceData:
     region: str
     initial_owner_id: int
     final_owner_id: int
+    legal_owner_id: int
     ownership_changes: int
     resource_production_type: Optional[str]
     resource_production: int

--- a/tools/game_stats_extractor/src/game_stats_extractor/models/intermediate.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/models/intermediate.py
@@ -61,6 +61,7 @@ class ProvinceData:
     province_name: str
     terrain_type: str
     is_coastal: bool
+    region: str
     initial_owner_id: int
     final_owner_id: int
     ownership_changes: int
@@ -85,7 +86,8 @@ class GameData:
     avg_update_interval_seconds: float
     winner_ids: list[int]
     victory_type: str  # "solo", "coalition", "unknown"
-    game_ended: bool
+    traitor_ids: list[int] = field(default_factory=list)
+    game_ended: bool = False
     players: list[PlayerData] = field(default_factory=list)
     provinces: list[ProvinceData] = field(default_factory=list)
     total_wars_declared: int = 0

--- a/tools/game_stats_extractor/src/game_stats_extractor/output.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/output.py
@@ -25,7 +25,7 @@ def _rp(v) -> float:
 
 def _provinces_columnar(provinces: list[ProvinceAggregate]) -> dict:
     cols = [
-        "province_id", "province_name", "terrain_type", "is_coastal",
+        "province_id", "province_name", "terrain_type", "is_coastal", "region",
         "games_appeared", "avg_ownership_changes", "contest_frequency",
         "win_correlation", "resource_production_type",
         "avg_resource_production", "avg_money_production", "avg_morale",
@@ -33,7 +33,7 @@ def _provinces_columnar(provinces: list[ProvinceAggregate]) -> dict:
     ]
     rows = [
         [
-            p.province_id, p.province_name, p.terrain_type, p.is_coastal,
+            p.province_id, p.province_name, p.terrain_type, p.is_coastal, p.region,
             p.games_appeared, _r(p.avg_ownership_changes), _rp(p.contest_frequency),
             _rp(p.win_correlation), p.resource_production_type,
             _r(p.avg_resource_production), _r(p.avg_money_production), _r(p.avg_morale),

--- a/tools/game_stats_extractor/src/game_stats_extractor/output.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/output.py
@@ -26,6 +26,7 @@ def _rp(v) -> float:
 def _provinces_columnar(provinces: list[ProvinceAggregate]) -> dict:
     cols = [
         "province_id", "province_name", "terrain_type", "is_coastal", "region",
+        "original_owner_nation",
         "games_appeared", "avg_ownership_changes", "contest_frequency",
         "win_correlation", "resource_production_type",
         "avg_resource_production", "avg_money_production", "avg_morale",
@@ -34,6 +35,7 @@ def _provinces_columnar(provinces: list[ProvinceAggregate]) -> dict:
     rows = [
         [
             p.province_id, p.province_name, p.terrain_type, p.is_coastal, p.region,
+            p.original_owner_nation,
             p.games_appeared, _r(p.avg_ownership_changes), _rp(p.contest_frequency),
             _rp(p.win_correlation), p.resource_production_type,
             _r(p.avg_resource_production), _r(p.avg_money_production), _r(p.avg_morale),

--- a/tools/game_stats_extractor/src/game_stats_extractor/output.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/output.py
@@ -4,7 +4,16 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from .models.aggregates import BuildingAggregate, CountryAggregate, GlobalAggregate, MetaInfo, ProvinceAggregate, TimeSeriesOutput
+from .models.aggregates import (
+    BuildingAggregate,
+    ClusterInfo,
+    CountryAggregate,
+    GlobalAggregate,
+    MetaInfo,
+    NationSimilarityAggregate,
+    ProvinceAggregate,
+    TimeSeriesOutput,
+)
 from .models.intermediate import GameData
 
 
@@ -48,7 +57,7 @@ def _provinces_columnar(provinces: list[ProvinceAggregate]) -> dict:
 
 def _countries_columnar(countries: list[CountryAggregate]) -> dict:
     cols = [
-        "nation_name", "games_played", "wins", "win_rate", "avg_final_vp",
+        "nation_name", "games_played", "human_games_played", "wins", "win_rate", "avg_final_vp",
         "avg_placement", "median_placement", "avg_final_provinces",
         "avg_initial_provinces", "avg_expansion", "avg_provinces_captured",
         "avg_provinces_lost", "elimination_rate", "avg_survival_days",
@@ -63,7 +72,7 @@ def _countries_columnar(countries: list[CountryAggregate]) -> dict:
     ]
     rows = [
         [
-            c.nation_name, c.games_played, c.wins, _r(c.win_rate), _r(c.avg_final_vp),
+            c.nation_name, c.games_played, c.human_games_played, c.wins, _r(c.win_rate), _r(c.avg_final_vp),
             _r(c.avg_placement), _r(c.median_placement), _r(c.avg_final_provinces),
             _r(c.avg_initial_provinces), _r(c.avg_expansion),
             _r(c.avg_provinces_captured), _r(c.avg_provinces_lost),
@@ -179,6 +188,27 @@ def _buildings_columnar(buildings: list[BuildingAggregate]) -> dict:
     return {"columns": cols, "rows": rows}
 
 
+def _nation_similarity_columnar(
+    nations: list[NationSimilarityAggregate], clusters: list[ClusterInfo]
+) -> dict:
+    cols = [
+        "nation_name", "games_played", "human_games_played",
+        "cluster_id", "pca_x", "pca_y", "top_buildings",
+    ]
+    rows = [
+        [
+            n.nation_name, n.games_played, n.human_games_played,
+            n.cluster_id, n.pca_x, n.pca_y, n.top_buildings,
+        ]
+        for n in nations
+    ]
+    return {
+        "columns": cols,
+        "rows": rows,
+        "clusters": [c.model_dump() for c in clusters],
+    }
+
+
 def write_output(
     output_dir: Path,
     global_agg: GlobalAggregate,
@@ -186,6 +216,8 @@ def write_output(
     province_aggs: list[ProvinceAggregate],
     timeseries_agg: TimeSeriesOutput,
     building_aggs: list[BuildingAggregate],
+    nation_similarity_aggs: list[NationSimilarityAggregate],
+    cluster_info: list[ClusterInfo],
     games: list[GameData],
     replay_dir: Path,
     failed_replays: int,
@@ -207,6 +239,10 @@ def write_output(
     _write_compact(output_dir / "countries.json",  _countries_columnar(country_aggs))
     _write_compact(output_dir / "timeseries.json", _timeseries_compact(timeseries_agg))
     _write_compact(output_dir / "buildings.json",  _buildings_columnar(building_aggs))
+    _write_compact(
+        output_dir / "nation_similarity.json",
+        _nation_similarity_columnar(nation_similarity_aggs, cluster_info),
+    )
 
     # Small files: readable indented JSON
     _write_json(output_dir / "global.json", global_agg.model_dump())

--- a/tools/game_stats_extractor/src/game_stats_extractor/pipeline.py
+++ b/tools/game_stats_extractor/src/game_stats_extractor/pipeline.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 from .aggregators.building_aggregator import BuildingAggregator
 from .aggregators.country_aggregator import CountryAggregator
 from .aggregators.global_aggregator import GlobalAggregator
+from .aggregators.nation_similarity_aggregator import NationSimilarityAggregator
 from .aggregators.province_aggregator import ProvinceAggregator
 from .aggregators.timeseries_aggregator import TimeSeriesAggregator
 from .extractors.replay_extractor import ReplayExtractor
@@ -91,11 +92,15 @@ class Pipeline:
         logger.info("Aggregating building statistics...")
         building_aggs = BuildingAggregator().aggregate(games)
 
+        logger.info("Aggregating nation build-similarity clusters...")
+        nation_similarity_aggs, cluster_info = NationSimilarityAggregator().aggregate(country_aggs)
+
         logger.info(
-            "Writing output: %d countries, %d provinces, %d building types",
+            "Writing output: %d countries, %d provinces, %d building types, %d clustered nations",
             len(country_aggs),
             len(province_aggs),
             len(building_aggs),
+            len(nation_similarity_aggs),
         )
         write_output(
             self.output_dir,
@@ -104,6 +109,8 @@ class Pipeline:
             province_aggs,
             timeseries_agg,
             building_aggs,
+            nation_similarity_aggs,
+            cluster_info,
             games,
             self.replays_dir,
             failed,


### PR DESCRIPTION
This pull request updates several statistics chart components in the documentation app to simplify tooltips and chart data, improve color scaling, and enhance clarity. The most significant changes involve removing the display of sample size/game counts from tooltips, switching to percentile-based color scales for win rates, and improving region labeling and color coding. Additionally, a new sidebar item for traitor wins is added.

**Statistics tooltip and data simplification:**
* Removed the display of the number of games/sample size from tooltips and chart data across various charts, including country, province, coalition, and player activity charts, to focus on more relevant metrics. [[1]](diffhunk://#diff-ea82b94de87f2e3285421dc71419a4ccaa49542c335b5fdba573dcb897fa8eceL65-R64) [[2]](diffhunk://#diff-397e3f0f7043154d38fe5a5342a9149fe1d60da12d05c725059356a0399cb5f8L60-R61) [[3]](diffhunk://#diff-76d099ff5018d167c58d106861a6f6fda341901f6b81e52b9aee96f3de37b7c3L60-R61) [[4]](diffhunk://#diff-85c30266eb846fff9c625d57236a749ab84320ddbf6f37f6541a8d60ba7b1c1bL58-R57) [[5]](diffhunk://#diff-54717a8dabda0ab68f335c9a9707f602585ef529fd852335212715220116ece1L61-R60) [[6]](diffhunk://#diff-05ef8848c7f057a36335450916a4afb2229d4acfa5298fd1e0ef6dd1f5dab519L58-R57) [[7]](diffhunk://#diff-89b5d941f7151776f39336f9f51e0feb43d8d84a0c4cfd7d3e253dc9942e5780L61-R60) [[8]](diffhunk://#diff-a2471c56f4a672e197f270f20df7b7d200e344149d04f55e2ef993ed8a8ad469L57-R56) [[9]](diffhunk://#diff-82d2c724d8536b17e32ed7619bb5723fa20fafe1ba41d69e7d723f8c19a1d515L107-R106) [[10]](diffhunk://#diff-01ad3ee5a2de56c78329bd13b85afed589f7febffa9a95a3fb2d276e59ad4df2L75-R77)

* Removed the `games` (number of games) property from chart data objects in many chart components, as it's no longer used in tooltips or displays. [[1]](diffhunk://#diff-ea82b94de87f2e3285421dc71419a4ccaa49542c335b5fdba573dcb897fa8eceL30) [[2]](diffhunk://#diff-397e3f0f7043154d38fe5a5342a9149fe1d60da12d05c725059356a0399cb5f8L30) [[3]](diffhunk://#diff-76d099ff5018d167c58d106861a6f6fda341901f6b81e52b9aee96f3de37b7c3L28) [[4]](diffhunk://#diff-85c30266eb846fff9c625d57236a749ab84320ddbf6f37f6541a8d60ba7b1c1bL27) [[5]](diffhunk://#diff-54717a8dabda0ab68f335c9a9707f602585ef529fd852335212715220116ece1L28) [[6]](diffhunk://#diff-05ef8848c7f057a36335450916a4afb2229d4acfa5298fd1e0ef6dd1f5dab519L28) [[7]](diffhunk://#diff-89b5d941f7151776f39336f9f51e0feb43d8d84a0c4cfd7d3e253dc9942e5780L28) [[8]](diffhunk://#diff-a2471c56f4a672e197f270f20df7b7d200e344149d04f55e2ef993ed8a8ad469L27) [[9]](diffhunk://#diff-82d2c724d8536b17e32ed7619bb5723fa20fafe1ba41d69e7d723f8c19a1d515L38) [[10]](diffhunk://#diff-01ad3ee5a2de56c78329bd13b85afed589f7febffa9a95a3fb2d276e59ad4df2L43)

**Color scaling and region labeling improvements:**
* Updated `CountryWinRateChart` to use a percentile-based color scale for bar colors, making win rate comparisons more visually meaningful, and added percentile calculation logic. [[1]](diffhunk://#diff-869d277af5defd8c64607b8f425ac2d4d3fe972af31bb7618d38e19f6384c757R13-R28) [[2]](diffhunk://#diff-869d277af5defd8c64607b8f425ac2d4d3fe972af31bb7618d38e19f6384c757L59-R62)
* Refactored `ProvinceStrategicScatterChart` to color provinces by region instead of terrain and to display human-friendly region labels.

**Chart and sidebar enhancements:**
* Changed `EliminationTimingDistributionChart` to display percentages instead of counts, dynamically generate bucket labels, and update tooltips/Y-axis accordingly for better clarity. [[1]](diffhunk://#diff-43dbe0e32cb243741ef4e5b5ae6337bbbc895c73a27205b0237031aa2009219dL18-R34) [[2]](diffhunk://#diff-43dbe0e32cb243741ef4e5b5ae6337bbbc895c73a27205b0237031aa2009219dL44-R62)
* Added a new "Traitor Wins" section to the statistics sidebar for improved navigation.